### PR TITLE
Implement the data model for the Codenames board game

### DIFF
--- a/server/model/card.go
+++ b/server/model/card.go
@@ -22,11 +22,15 @@ func NewCard(word string, classification int) *Card {
 }
 
 // Reveal sets this Card's IsRevealed field to true. Returns this Card's
-// classification.
+// classification. Returns -1 if this Card has already been revealed.
 //
 // A Card that's been revealed can't be "un"-revealed; revealing a Card is an
 // idempotent operation.
 func (c *Card) Reveal() int {
+	if c.IsRevealed {
+		return -1
+	}
+
 	c.IsRevealed = true
 	return c.Classification
 }

--- a/server/model/card.go
+++ b/server/model/card.go
@@ -1,0 +1,32 @@
+package model
+
+// Card stores information about one of the 25 cards on a Codenames board.
+type Card struct {
+	Word       string
+	IsRevealed bool
+
+	// Classification represents what type of card this is. Is set to 0 if this
+	// card is a neutral card, 1 if it's one of red team's cards, 2 if it's one
+	// of blue team's cards, and 3 if it's the assassin.
+	Classification int
+}
+
+// NewCard returns a pointer to a new Card object that's configured with the
+// provided field values.
+func NewCard(word string, classification int) *Card {
+	return &Card{
+		Word:           word,
+		IsRevealed:     false,
+		Classification: classification,
+	}
+}
+
+// Reveal sets this Card's IsRevealed field to true. Returns this Card's
+// classification.
+//
+// A Card that's been revealed can't be "un"-revealed; revealing a Card is an
+// idempotent operation.
+func (c *Card) Reveal() int {
+	c.IsRevealed = true
+	return c.Classification
+}

--- a/server/model/game.go
+++ b/server/model/game.go
@@ -1,15 +1,22 @@
 package model
 
-import "fmt"
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
 
 const (
 	maxRedTeamScore  = 9
 	maxBlueTeamScore = 8
 )
 
+type gameBoard [5][5]*Card
+
 // Game maintains state about an avtive game of Codenames, and exposes functions
 // which mutate that state, allowing the game to progress.
 type Game struct {
+	Board            gameBoard
 	RedTeamScore     int
 	BlueTeamScore    int
 	IsItRedTeamsTurn bool
@@ -25,21 +32,74 @@ type Game struct {
 }
 
 // NewGame returns a pointer to a new Game object with initialized fields.
-func NewGame() (*Game, error) {
-	// TODO: accept dictionary []string as an arg, and call createBoard()
+func NewGame(dictionary [25]string) *Game {
 	return &Game{
+		Board:            createBoard(dictionary),
 		RedTeamScore:     0,
 		BlueTeamScore:    0,
 		IsItRedTeamsTurn: true,
 		RemainingFlips:   -1,
 		IsFinished:       0,
-	}, nil
+	}
+}
+
+// createBoard populates a gameBoard with 25 new pointers to Card objects, and
+// returns it.
+func createBoard(dictionary [25]string) gameBoard {
+	rand.Seed(time.Now().UnixNano())
+
+	// Shuffle the dictionary.
+	rand.Shuffle(len(dictionary), func(i, j int) {
+		dictionary[i], dictionary[j] = dictionary[j], dictionary[i]
+	})
+
+	// Create Cards with the appropriate classifications.
+	cardNum := 0
+	var board gameBoard
+	for r := 0; r < len(board); r++ {
+		for c := 0; c < len(board[r]); c++ {
+			var classification int
+			if cardNum < maxRedTeamScore {
+				classification = 1
+			} else if cardNum < maxRedTeamScore+maxBlueTeamScore {
+				classification = 2
+			} else if cardNum < maxRedTeamScore+maxBlueTeamScore+1 {
+				classification = 3
+			} else {
+				classification = 0
+			}
+
+			board[r][c] = NewCard(dictionary[cardNum], classification)
+			cardNum++
+		}
+	}
+
+	// Shuffle the board after assigning Cards their classifications in a linear
+	// fashion. Inspired by the Fisher-Yates algorithm.
+	for i := len(board) - 1; i > 0; i-- {
+		for j := len(board[i]) - 1; j > 0; j-- {
+			m := rand.Intn(i + 1)
+			n := rand.Intn(j + 1)
+
+			temp := board[i][j]
+			board[i][j] = board[m][n]
+			board[m][n] = temp
+		}
+	}
+
+	return board
 }
 
 // ChangeTurn changes which team's turn it is.
 func (g *Game) ChangeTurn() {
 	g.IsItRedTeamsTurn = !g.IsItRedTeamsTurn
 	g.RemainingFlips = -1
+}
+
+// RevealCard reveals the Card on the rth row and the cth column of the
+// gameBoard. Calls that Card's Reveal() method.
+func (g *Game) RevealCard(r, c int) int {
+	return g.Board[r][c].Reveal()
 }
 
 // SetFlipsForCurrentTurn sets the number of remaining card flips for the active

--- a/server/model/game.go
+++ b/server/model/game.go
@@ -91,10 +91,17 @@ func createBoard(dictionary [25]string) gameBoard {
 	return board
 }
 
-// ChangeTurn changes which team's turn it is.
-func (g *Game) ChangeTurn() {
+// ChangeTurn changes which team's turn it is. Returns an error if called before
+// it's possible to change who's turn it is (i.e., if a team's spymaster has yet
+// to give their clue).
+func (g *Game) ChangeTurn() error {
+	if g.RemainingFlips == -1 {
+		return fmt.Errorf("The current team's spymaster hasn't given their clue yet")
+	}
+
 	g.IsItRedTeamsTurn = !g.IsItRedTeamsTurn
 	g.RemainingFlips = -1
+	return nil
 }
 
 // RevealCard reveals the Card on the rth row and the cth column of the

--- a/server/model/game.go
+++ b/server/model/game.go
@@ -1,0 +1,85 @@
+package model
+
+import "fmt"
+
+const (
+	maxRedTeamScore  = 9
+	maxBlueTeamScore = 8
+)
+
+// Game maintains state about an avtive game of Codenames, and exposes functions
+// which mutate that state, allowing the game to progress.
+type Game struct {
+	RedTeamScore     int
+	BlueTeamScore    int
+	IsItRedTeamsTurn bool
+
+	// RemainingFlips is set to -1 if a team has ended their turn, and the other
+	// team's spymaster has yet to deliver their clue.
+	RemainingFlips int
+
+	// IsFinished stores whether this game has concluded or not. Is set to 0 if
+	// the game isn't finished yet, 1 if the red team won, or 2 if the blue team
+	// won.
+	IsFinished int
+}
+
+// NewGame returns a pointer to a new Game object with initialized fields.
+func NewGame() (*Game, error) {
+	// TODO: accept dictionary []string as an arg, and call createBoard()
+	return &Game{
+		RedTeamScore:     0,
+		BlueTeamScore:    0,
+		IsItRedTeamsTurn: true,
+		RemainingFlips:   -1,
+		IsFinished:       0,
+	}, nil
+}
+
+// ChangeTurn changes which team's turn it is.
+func (g *Game) ChangeTurn() {
+	g.IsItRedTeamsTurn = !g.IsItRedTeamsTurn
+	g.RemainingFlips = -1
+}
+
+// SetFlipsForCurrentTurn sets the number of remaining card flips for the active
+// turn. Typically called after ChangeTurn() is called and the active team's
+// spymaster delivers their clue.
+func (g *Game) SetFlipsForCurrentTurn(flips int) error {
+	// Input validation.
+	if flips <= 0 {
+		return fmt.Errorf("flips: %d must be greater than 0", flips)
+	}
+	redTeamNumUnrevealedCards := maxRedTeamScore - g.RedTeamScore
+	if g.IsItRedTeamsTurn && flips > redTeamNumUnrevealedCards {
+		return fmt.Errorf("flips: %d must not be greater than red team's"+
+			" number of remaining unrevealed cards: %d",
+			flips,
+			redTeamNumUnrevealedCards,
+		)
+	}
+	blueTeamNumUnrevealedCards := maxBlueTeamScore - g.BlueTeamScore
+	if !g.IsItRedTeamsTurn && flips > blueTeamNumUnrevealedCards {
+		return fmt.Errorf("flips: %d must not be greater than blue team's"+
+			" number of remaining unrevealed cards: %d",
+			flips,
+			blueTeamNumUnrevealedCards,
+		)
+	}
+
+	g.RemainingFlips = flips
+	return nil
+}
+
+// EvaluateWinner re-evaluates the state of the game, mutating the game's
+// IsFinished field, if necessary. Returns whether the game is still ongoing,
+// the red team won, or the blue team won.
+func (g *Game) EvaluateWinner() int {
+	// Assumes that both teams can't both reach their max scores.
+	if g.RedTeamScore >= maxRedTeamScore {
+		g.IsFinished = 1
+	} else if g.BlueTeamScore >= maxBlueTeamScore {
+		g.IsFinished = 2
+	}
+	return g.IsFinished
+}

--- a/server/model/game.go
+++ b/server/model/game.go
@@ -9,9 +9,10 @@ import (
 const (
 	maxRedTeamScore  = 9
 	maxBlueTeamScore = 8
+	boardSize        = 5
 )
 
-type gameBoard [5][5]*Card
+type gameBoard [boardSize][boardSize]*Card
 
 // Game maintains state about an avtive game of Codenames, and exposes functions
 // which mutate that state, allowing the game to progress.
@@ -98,8 +99,15 @@ func (g *Game) ChangeTurn() {
 
 // RevealCard reveals the Card on the rth row and the cth column of the
 // gameBoard. Calls that Card's Reveal() method.
-func (g *Game) RevealCard(r, c int) int {
-	return g.Board[r][c].Reveal()
+func (g *Game) RevealCard(r, c int) error {
+	// Input validation.
+	if r < 0 || r >= boardSize || c < 0 || c >= boardSize {
+		return fmt.Errorf("The provided r (%d) and c (%d) must be within the range: [0, %d)",
+			r, c, boardSize)
+	}
+
+	g.Board[r][c].Reveal()
+	return nil
 }
 
 // SetFlipsForCurrentTurn sets the number of remaining card flips for the active

--- a/server/model/game_test.go
+++ b/server/model/game_test.go
@@ -31,3 +31,29 @@ func TestGameCreation(t *testing.T) {
 			got.IsFinished, 0)
 	}
 }
+
+// TestFlipOutOfBounds makes sure that the game state doesn't change if flipping
+// a card that doesn't exist, or that is out of bounds, is attempted.
+func TestFlipOutOfBounds(t *testing.T) {
+	dictionary := [25]string{"foo", "bar"}
+	game := NewGame(dictionary)
+
+	tests := []struct {
+		r int
+		c int
+	}{
+		{-1, 0},
+		{0, -1},
+		{-1, -1},
+		{boardSize, 0},
+		{0, boardSize},
+		{boardSize, boardSize},
+	}
+	for _, c := range tests {
+		err := game.RevealCard(c.r, c.c)
+		if err == nil {
+			t.Fatalf("Expected RevealCard(%d, %d) to return an error, but it did not",
+				c.r, c.c)
+		}
+	}
+}

--- a/server/model/game_test.go
+++ b/server/model/game_test.go
@@ -1,0 +1,33 @@
+package model
+
+import "testing"
+
+// TestGameCreation tests the NewGame() func, and that the primitive fields of
+// the returned *Game object are initialized to their expected values.
+func TestGameCreation(t *testing.T) {
+	dictionary := [25]string{"word", "list"}
+	got := NewGame(dictionary)
+
+	// Make sure that all primitive fields are set appropriately for a Game that
+	// has just begun.
+	if got.RedTeamScore != 0 {
+		t.Errorf("Unexpected RedTeamScore. got: %d, want: %d\n",
+			got.RedTeamScore, 0)
+	}
+	if got.BlueTeamScore != 0 {
+		t.Errorf("Unexpected BlueTeamScore. got: %d, want: %d\n",
+			got.BlueTeamScore, 0)
+	}
+	if got.IsItRedTeamsTurn != true {
+		t.Errorf("Unexpected value for IsItRedTeamsTurn. got: %v, want: %v\n",
+			got.IsItRedTeamsTurn, true)
+	}
+	if got.RemainingFlips != -1 {
+		t.Errorf("Unexpected value for RemainingFlips. got: %d, want: %d\n",
+			got.RemainingFlips, -1)
+	}
+	if got.IsFinished != 0 {
+		t.Errorf("Unexpected value for IsFinished. got: %d, want: %d\n",
+			got.IsFinished, 0)
+	}
+}

--- a/server/model/game_test.go
+++ b/server/model/game_test.go
@@ -246,3 +246,48 @@ func TestCommonScenarios(t *testing.T) {
 			game.IsFinished, 1)
 	}
 }
+
+// TestEndgameScenarios makes sure that the game state updates accordingly when
+// a game-ending move is made.
+func TestEndgameScenarios(t *testing.T) {
+	dictionary := [25]string{"foo", "bar"}
+	game := NewGame(dictionary)
+	dummyGameBoard := gameBoard{
+		[5]*Card{
+			NewCard("redTeam", 1),
+			NewCard("blueTeam", 2),
+		},
+	}
+
+	tests := []struct {
+		redTeamScore       int
+		blueTeamScore      int
+		isItRedTeamsTurn   bool
+		expectedIsFinished int
+	}{
+		{maxRedTeamScore - 1, 0, true, 1},
+		{0, maxBlueTeamScore - 1, false, 2},
+	}
+	for _, c := range tests {
+		// Prepare the game state for the next test case.
+		dummyGameBoard[0][0].IsRevealed = false
+		dummyGameBoard[0][1].IsRevealed = false
+		game.Board = dummyGameBoard
+		game.RedTeamScore = c.redTeamScore
+		game.BlueTeamScore = c.blueTeamScore
+		game.IsItRedTeamsTurn = c.isItRedTeamsTurn
+		game.IsFinished = 0
+
+		game.SetFlipsForCurrentTurn(1)
+		if c.isItRedTeamsTurn {
+			game.RevealCard(0, 0)
+		} else {
+			game.RevealCard(0, 1)
+		}
+
+		if game.IsFinished != c.expectedIsFinished {
+			t.Errorf("unexpected IsFinished: got: %d, want: %d",
+				game.IsFinished, c.expectedIsFinished)
+		}
+	}
+}

--- a/server/model/game_test.go
+++ b/server/model/game_test.go
@@ -32,6 +32,36 @@ func TestGameCreation(t *testing.T) {
 	}
 }
 
+// TestInvalidClues makes sure that a team's spymaster cannot give a clue with
+// an invalid number: a number that's either greater than that team's number of
+// remaining cards, or less than 1.
+func TestInvalidClues(t *testing.T) {
+	dictionary := [25]string{"foo", "bar"}
+	game := NewGame(dictionary)
+
+	tests := []struct {
+		clue             int
+		redTeamScore     int
+		blueTeamScore    int
+		isItRedTeamsTurn bool
+	}{
+		{-1, 0, 0, true},
+		{0, 0, 0, true},
+		{maxRedTeamScore, 1, 0, true},
+		{maxBlueTeamScore, 0, 1, false},
+	}
+	for _, c := range tests {
+		game.RedTeamScore = c.redTeamScore
+		game.BlueTeamScore = c.blueTeamScore
+		game.IsItRedTeamsTurn = c.isItRedTeamsTurn
+
+		err := game.SetFlipsForCurrentTurn(c.clue)
+		if err == nil {
+			t.Fatalf("expected SetFlipsForCurrentTurn(%d) to return an error, but ti did not", c.clue)
+		}
+	}
+}
+
 // TestFlipOutOfBounds makes sure that the game state doesn't change if flipping
 // a card that doesn't exist, or that is out of bounds, is attempted.
 func TestFlipOutOfBounds(t *testing.T) {


### PR DESCRIPTION
Closes #1 

This PR proposes to implement the functionality to represent all possible states of a legal game of Codenames. The objects and functions that make up the data model enforce the board game's rules by returning errors if illegal or invalid mutations of the game state are attempted.

Users of the front-end web application in this repo won't be directly interacting with this data model when they play; functionality  that will translate users' actions with game state/data model mutations is planned to be implemented in the future.