### PR TITLE
Make amendments to the "create game" screen

### DIFF
--- a/client/src/components/DisplayName.css
+++ b/client/src/components/DisplayName.css
@@ -1,0 +1,3 @@
+#emph-display-name {
+  font-weight: bold;
+}

--- a/client/src/components/DisplayName.tsx
+++ b/client/src/components/DisplayName.tsx
@@ -1,0 +1,28 @@
+// This component exists in case I want to let users change their display names
+// after they've already provided one before they join a game. Perhaps a
+// "change" button could exist, and when clicked, a text field would be
+// presented.
+
+import React from 'react';
+import './DisplayName.css';
+import { connect, ConnectedProps } from 'react-redux';
+import { RootState } from '../store';
+
+// Redux business.
+const mapState = (state: RootState) => ({
+  displayName: state.user.displayName,
+});
+const connector = connect(mapState);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+// Component.
+
+const DisplayName: React.FC<PropsFromRedux> = (props: PropsFromRedux) => {
+  return (
+    <p>
+      Display name: <span id="emph-display-name">{props.displayName}</span>
+    </p>
+  );
+};
+
+export default connector(DisplayName);

--- a/client/src/components/TeamMembersList.css
+++ b/client/src/components/TeamMembersList.css
@@ -1,0 +1,6 @@
+#indented-col {
+  margin: 0.5rem;
+  padding: 1.5rem;
+  background: #eee;
+  border-radius: 12px;
+}

--- a/client/src/components/TeamMembersList.tsx
+++ b/client/src/components/TeamMembersList.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import './TeamMembersList.css';
+
+interface Props {
+  title: string;
+}
+
+const TeamMembersList: React.FC<Props> = (props: Props) => (
+  <div id="indented-col">
+    <h2>{props.title}</h2>
+  </div>
+);
+
+export default TeamMembersList;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -184,26 +184,39 @@ input[type='text']:focus {
 
 button {
   padding: 0.75rem 1.25rem;
-  background: #00695c;
-  color: white;
-  font-weight: bold;
-  font-size: 1rem;
   border: none;
   border-radius: 6px;
+  font-weight: bold;
+  font-size: 1rem;
   transition: all 0.2s;
 }
-
 button:hover {
   cursor: pointer;
-  background: #00897b;
+}
+button:focus {
+  outline: none;
 }
 
-button:active {
+.primary-btn {
+  background: #00695c;
+  color: white;
+}
+.primary-btn:hover {
+  background: #00897b;
+}
+.primary-btn:active {
   background: #00695c;
 }
 
-button:focus {
-  outline: none;
+.secondary-btn {
+  background: #eee;
+  color: #212121;
+}
+.secondary-btn:hover {
+  background: #ddd;
+}
+.secondary-btn:active {
+  background: #eee;
 }
 
 /* Cards */

--- a/client/src/screens/CreateGameScreen.css
+++ b/client/src/screens/CreateGameScreen.css
@@ -1,16 +1,8 @@
 .even-columns {
   display: flex;
 }
-
-.even-columns > div {
+.even-columns > * {
   flex: 1 1 0px;
-}
-
-.indented-col {
-  margin: 0.5rem;
-  padding: 1.5rem;
-  background: #eee;
-  border-radius: 12px;
 }
 
 #create-game-btn {

--- a/client/src/screens/CreateGameScreen.css
+++ b/client/src/screens/CreateGameScreen.css
@@ -1,0 +1,18 @@
+.even-columns {
+  display: flex;
+}
+
+.even-columns > div {
+  flex: 1 1 0px;
+}
+
+.indented-col {
+  margin: 0.5rem;
+  padding: 1.5rem;
+  background: #eee;
+  border-radius: 12px;
+}
+
+#create-game-btn {
+  margin-top: 2rem;
+}

--- a/client/src/screens/CreateGameScreen.tsx
+++ b/client/src/screens/CreateGameScreen.tsx
@@ -18,16 +18,16 @@ const CreateGameScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => (
       <h1>Create a New Game</h1>
       <h3>{props.gameID.toUpperCase()}</h3>
       <div className="col-3">
-        <h2>Red Team</h2>
-      </div>
-      <div className="col-3">
-        <h2>Blue Team</h2>
-      </div>
-      <div className="col-3">
         <button type="button">Join Red Team</button>
         <button type="button">Join Blue Team</button>
         <button type="button">Change Some Other Setting</button>
         <button type="button">Create Game</button>
+      </div>
+      <div className="col-3">
+        <h2>Red Team</h2>
+      </div>
+      <div className="col-3">
+        <h2>Blue Team</h2>
       </div>
     </div>
   </div>

--- a/client/src/screens/CreateGameScreen.tsx
+++ b/client/src/screens/CreateGameScreen.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import './CreateGameScreen.css';
 import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from '../store';
+import DisplayName from '../components/DisplayName';
 
 // Redux business.
 
@@ -20,6 +21,7 @@ const CreateGameScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => (
         <div>
           <h1>Create a New Game</h1>
           <h3>{props.gameID.toUpperCase()}</h3>
+          <DisplayName />
           <button className="secondary-btn" type="button">
             Join Red Team
           </button>

--- a/client/src/screens/CreateGameScreen.tsx
+++ b/client/src/screens/CreateGameScreen.tsx
@@ -3,6 +3,7 @@ import './CreateGameScreen.css';
 import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from '../store';
 import DisplayName from '../components/DisplayName';
+import TeamMembersList from '../components/TeamMembersList';
 
 // Redux business.
 
@@ -35,12 +36,8 @@ const CreateGameScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => (
             Create Game
           </button>
         </div>
-        <div className="indented-col">
-          <h2>Red Team</h2>
-        </div>
-        <div className="indented-col">
-          <h2>Blue Team</h2>
-        </div>
+        <TeamMembersList title="Red Team" />
+        <TeamMembersList title="Blue Team" />
       </div>
     </div>
   </div>

--- a/client/src/screens/CreateGameScreen.tsx
+++ b/client/src/screens/CreateGameScreen.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import './CreateGameScreen.css';
 import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from '../store';
 
@@ -15,19 +16,29 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 const CreateGameScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => (
   <div className="container centered-container">
     <div className="card">
-      <h1>Create a New Game</h1>
-      <h3>{props.gameID.toUpperCase()}</h3>
-      <div className="col-3">
-        <button type="button">Join Red Team</button>
-        <button type="button">Join Blue Team</button>
-        <button type="button">Change Some Other Setting</button>
-        <button type="button">Create Game</button>
-      </div>
-      <div className="col-3">
-        <h2>Red Team</h2>
-      </div>
-      <div className="col-3">
-        <h2>Blue Team</h2>
+      <div className="even-columns">
+        <div>
+          <h1>Create a New Game</h1>
+          <h3>{props.gameID.toUpperCase()}</h3>
+          <button className="secondary-btn" type="button">
+            Join Red Team
+          </button>
+          <button className="secondary-btn" type="button">
+            Join Blue Team
+          </button>
+          <button className="secondary-btn" type="button">
+            Change Some Other Setting
+          </button>
+          <button className="primary-btn" id="create-game-btn" type="button">
+            Create Game
+          </button>
+        </div>
+        <div className="indented-col">
+          <h2>Red Team</h2>
+        </div>
+        <div className="indented-col">
+          <h2>Blue Team</h2>
+        </div>
       </div>
     </div>
   </div>

--- a/client/src/screens/LandingScreen.tsx
+++ b/client/src/screens/LandingScreen.tsx
@@ -37,7 +37,9 @@ const LandingScreen: React.FC<Props> = (props: Props) => {
               placeholder="game-id"
               onChange={(e) => setGameID(e.target.value)}
             />
-            <button type="submit">Play</button>
+            <button className="primary-btn" type="submit">
+              Play
+            </button>
           </form>
         </div>
         <p className="subtext">

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,8 +1,10 @@
 import { combineReducers, createStore } from 'redux';
 import gameReducer from './game/reducers';
+import userReducer from './user/reducers';
 
 const rootReducer = combineReducers({
   game: gameReducer,
+  user: userReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/client/src/store/user/actions.ts
+++ b/client/src/store/user/actions.ts
@@ -1,0 +1,9 @@
+import { UserActionTypes, SET_DISPLAY_NAME } from './types';
+
+// Action creator for the SET_DISPLAY_NAME action type.
+export default function setDisplayName(displayName: string): UserActionTypes {
+  return {
+    type: SET_DISPLAY_NAME,
+    payload: displayName,
+  };
+}

--- a/client/src/store/user/reducers.ts
+++ b/client/src/store/user/reducers.ts
@@ -1,0 +1,20 @@
+import { UserState, UserActionTypes, SET_DISPLAY_NAME } from './types';
+
+const initialState: UserState = {
+  displayName: '',
+};
+
+export default function userReducer(
+  state = initialState,
+  action: UserActionTypes,
+): UserState {
+  switch (action.type) {
+    case SET_DISPLAY_NAME:
+      return {
+        ...state,
+        displayName: action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/client/src/store/user/types.ts
+++ b/client/src/store/user/types.ts
@@ -1,0 +1,10 @@
+export interface UserState {
+  displayName: string;
+}
+
+export const SET_DISPLAY_NAME = 'SET_DISPLAY_NAME ';
+interface SetDisplayNameAction {
+  type: typeof SET_DISPLAY_NAME;
+  payload: string;
+}
+export type UserActionTypes = SetDisplayNameAction;


### PR DESCRIPTION
This PR relocates a few interactive elements on the "create new game" screen (mostly buttons), and fleshes out some of the stylings for all elements on this screen. It also creates a place for a user's chosen display name to live in the Redux global store.