### PR TITLE
Create first draft of BoardScreen

### DIFF
--- a/client/src/components/Board.css
+++ b/client/src/components/Board.css
@@ -1,4 +1,9 @@
 #board-container {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-auto-rows: 6rem;
+  column-gap: 0.75rem;
+  row-gap: 0.75rem;
   margin-left: 0.5rem;
   padding: 1.5rem;
   background: #eee;

--- a/client/src/components/Board.css
+++ b/client/src/components/Board.css
@@ -1,0 +1,6 @@
+#board-container {
+  margin-left: 0.5rem;
+  padding: 1.5rem;
+  background: #eee;
+  border-radius: 12px;
+}

--- a/client/src/components/Board.tsx
+++ b/client/src/components/Board.tsx
@@ -1,10 +1,26 @@
 import React from 'react';
 import './Board.css';
+import { connect, ConnectedProps } from 'react-redux';
+import { RootState } from '../store';
+import { Card } from '../store/board/types';
+import CardComponent from './Card';
 
-const Board: React.FC = () => (
+// React business.
+
+const mapState = (state: RootState) => ({
+  board: state.board.board,
+});
+const connector = connect(mapState);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+// Component.
+
+const Board: React.FC<PropsFromRedux> = (props: PropsFromRedux) => (
   <div id="board-container">
-    <p>game board goes here</p>
+    {props.board.map((card: Card, index) => (
+      <CardComponent key={`${card.word}+${index}`} index={index} />
+    ))}
   </div>
 );
 
-export default Board;
+export default connector(Board);

--- a/client/src/components/Board.tsx
+++ b/client/src/components/Board.tsx
@@ -5,7 +5,7 @@ import { RootState } from '../store';
 import { Card } from '../store/board/types';
 import CardComponent from './Card';
 
-// React business.
+// Redux business.
 
 const mapState = (state: RootState) => ({
   board: state.board.board,

--- a/client/src/components/Board.tsx
+++ b/client/src/components/Board.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import './Board.css';
+
+const Board: React.FC = () => (
+  <div id="board-container">
+    <p>game board goes here</p>
+  </div>
+);
+
+export default Board;

--- a/client/src/components/BoardInfo.css
+++ b/client/src/components/BoardInfo.css
@@ -1,0 +1,13 @@
+#board-info-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+}
+
+#red-team-score {
+  color: #ff3a30;
+}
+#blue-team-score {
+  color: #007bff;
+}

--- a/client/src/components/BoardInfo.tsx
+++ b/client/src/components/BoardInfo.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import './BoardInfo.css';
 
 // Redux business.
+// TODO: wire up corresponding fields in the global store (like game score, for
+// instance) once they're added.
 
 // Component.
 

--- a/client/src/components/BoardInfo.tsx
+++ b/client/src/components/BoardInfo.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import './BoardInfo.css';
+
+// Redux business.
+
+// Component.
+
+const BoardInfo: React.FC = () => (
+  <div id="board-info-container">
+    <div>
+      <h1>
+        <span id="red-team-score">5</span> - <span id="blue-team-score">4</span>
+      </h1>
+      <h3>BLUE TEAM'S TURN</h3>
+    </div>
+    <div>
+      <h1>Clue: Foo 2</h1>
+    </div>
+    <div>
+      <button className="primary-btn" type="button">
+        Vote to End Turn
+      </button>
+    </div>
+  </div>
+);
+
+export default BoardInfo;

--- a/client/src/components/Card.css
+++ b/client/src/components/Card.css
@@ -3,6 +3,23 @@
   align-items: center;
   justify-content: center;
   background: white;
+  transition: all 0.2s;
+}
+#card-container:hover {
+  cursor: pointer;
+  transform: scale(1.05);
+  box-shadow: 0 14px 28px rgba(27, 33, 48, 0.06),
+    0 10px 10px rgba(27, 33, 48, 0.02);
+  -webkit-box-shadow: 0 14px 28px rgba(27, 33, 48, 0.06),
+    0 10px 10px rgba(27, 33, 48, 0.02);
+  -moz-box-shadow: 0 14px 28px rgba(27, 33, 48, 0.06),
+    0 10px 10px rgba(27, 33, 48, 0.02);
+}
+#card-container:active {
+  transform: scale(1);
+  box-shadow: none;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
 }
 
 #card-word {

--- a/client/src/components/Card.css
+++ b/client/src/components/Card.css
@@ -1,0 +1,11 @@
+#card-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: white;
+}
+
+#card-word {
+  font-size: 1rem;
+  font-weight: bold;
+}

--- a/client/src/components/Card.tsx
+++ b/client/src/components/Card.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import './Card.css';
+import { connect, ConnectedProps } from 'react-redux';
+import { RootState } from '../store';
+
+// React business.
+
+const mapState = (state: RootState) => ({
+  board: state.board.board,
+});
+const connector = connect(mapState);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+// Component.
+
+interface ComponentProps {
+  index: number;
+}
+type Props = PropsFromRedux & ComponentProps;
+
+const Card: React.FC<Props> = (props: Props) => {
+  const curCard = props.board[props.index];
+
+  return (
+    <div id="card-container">
+      <span id="card-word">{curCard.word.toUpperCase()}</span>
+    </div>
+  );
+};
+
+export default connector(Card);

--- a/client/src/components/Card.tsx
+++ b/client/src/components/Card.tsx
@@ -3,7 +3,7 @@ import './Card.css';
 import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from '../store';
 
-// React business.
+// Redux business.
 
 const mapState = (state: RootState) => ({
   board: state.board.board,

--- a/client/src/screens/BoardScreen.css
+++ b/client/src/screens/BoardScreen.css
@@ -1,0 +1,9 @@
+#board-screen-card {
+  display: flex;
+}
+#small-col {
+  flex: 1 1 0px;
+}
+#big-col {
+  flex: 2 1 0px;
+}

--- a/client/src/screens/BoardScreen.tsx
+++ b/client/src/screens/BoardScreen.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import './BoardScreen.css';
+import Board from '../components/Board';
+
+const BoardScreen: React.FC = () => (
+  <div className="container centered-container">
+    <div id="board-screen-card" className="card">
+      <div id="small-col">
+        <button className="secondary-btn" type="button">
+          Placeholder
+        </button>
+      </div>
+      <div id="big-col">
+        <Board />
+      </div>
+    </div>
+  </div>
+);
+
+export default BoardScreen;

--- a/client/src/screens/BoardScreen.tsx
+++ b/client/src/screens/BoardScreen.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import './BoardScreen.css';
 import Board from '../components/Board';
+import BoardInfo from '../components/BoardInfo';
 
 const BoardScreen: React.FC = () => (
   <div className="container centered-container">
     <div id="board-screen-card" className="card">
       <div id="small-col">
-        <button className="secondary-btn" type="button">
-          Placeholder
-        </button>
+        <BoardInfo />
       </div>
       <div id="big-col">
         <Board />

--- a/client/src/screens/GameScreen.tsx
+++ b/client/src/screens/GameScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { RootState } from '../store';
-import { setIsCreated, setGameID } from '../store/game/actions';
+import { setIsCreated, setGameID, setIsJoined } from '../store/game/actions';
 import Loading from '../components/Loading';
 import CreateGameScreen from './CreateGameScreen';
 
@@ -15,10 +15,12 @@ import CreateGameScreen from './CreateGameScreen';
 
 const mapState = (state: RootState) => ({
   isCreated: state.game.isCreated,
+  isJoined: state.game.isJoined,
 });
 const mapDispatch = {
   setGameID: (id: string) => setGameID(id),
   setIsCreated: (isCreated: boolean) => setIsCreated(isCreated),
+  setIsJoined: (isJoined: boolean) => setIsJoined(isJoined),
 };
 const connector = connect(mapState, mapDispatch);
 type PropsFromRedux = ConnectedProps<typeof connector>;
@@ -41,21 +43,23 @@ const GameScreen: React.FC<Props> = (props: Props) => {
     // with the provided ID doesn't exist, therefore we'll be creating a new
     // one.
     props.setIsCreated(false);
+    props.setIsJoined(false);
 
     setIsLoading(false);
   }, []);
 
-  return (
-    <>
-      {isLoading && <Loading />}
-      {!isLoading && (
-        <>
-          {props.isCreated && <p>join game screen goes here</p>}
-          {!props.isCreated && <CreateGameScreen />}
-        </>
-      )}
-    </>
-  );
+  // Render.
+
+  if (isLoading) {
+    return <Loading />;
+  }
+  if (props.isJoined) {
+    return <p>game board screen goes here</p>;
+  }
+  if (props.isCreated) {
+    return <p>join game screen goes here</p>;
+  }
+  return <CreateGameScreen />;
 };
 
 export default connector(GameScreen);

--- a/client/src/screens/GameScreen.tsx
+++ b/client/src/screens/GameScreen.tsx
@@ -5,6 +5,7 @@ import { RootState } from '../store';
 import { setIsCreated, setGameID, setIsJoined } from '../store/game/actions';
 import Loading from '../components/Loading';
 import CreateGameScreen from './CreateGameScreen';
+import BoardScreen from './BoardScreen';
 
 // In this component, a Websocket connection is established with the server.
 // Depending on whether the game with the provided gameID has already been
@@ -54,7 +55,7 @@ const GameScreen: React.FC<Props> = (props: Props) => {
     return <Loading />;
   }
   if (props.isJoined) {
-    return <p>game board screen goes here</p>;
+    return <BoardScreen />;
   }
   if (props.isCreated) {
     return <p>join game screen goes here</p>;

--- a/client/src/store/board/actions.ts
+++ b/client/src/store/board/actions.ts
@@ -1,0 +1,9 @@
+import { BoardActionTypes, Card, SET_BOARD } from './types';
+
+// Action creator for the SET_BOARD action type.
+export default function setBoard(board: Card[]): BoardActionTypes {
+  return {
+    type: SET_BOARD,
+    payload: board,
+  };
+}

--- a/client/src/store/board/reducers.ts
+++ b/client/src/store/board/reducers.ts
@@ -1,0 +1,146 @@
+import { BoardState, BoardActionTypes, SET_BOARD } from './types';
+
+const initialState: BoardState = {
+  board: [
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+    // {
+    //   word: 'foo',
+    //   isRevealed: false,
+    //   classification: 0,
+    // },
+  ],
+};
+
+export default function boardReducer(
+  state = initialState,
+  action: BoardActionTypes,
+): BoardState {
+  switch (action.type) {
+    case SET_BOARD:
+      return {
+        ...state,
+        board: action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/client/src/store/board/types.ts
+++ b/client/src/store/board/types.ts
@@ -1,0 +1,16 @@
+export interface Card {
+  word: string;
+  isRevealed: boolean;
+  classification: number;
+}
+
+export interface BoardState {
+  board: Card[];
+}
+
+export const SET_BOARD = 'SET_BOARD';
+interface SetBoardAction {
+  type: typeof SET_BOARD;
+  payload: Card[];
+}
+export type BoardActionTypes = SetBoardAction;

--- a/client/src/store/game/actions.ts
+++ b/client/src/store/game/actions.ts
@@ -1,4 +1,9 @@
-import { GameActionTypes, SET_GAME_ID, SET_IS_CREATED } from './types';
+import {
+  GameActionTypes,
+  SET_GAME_ID,
+  SET_IS_CREATED,
+  SET_IS_JOINED,
+} from './types';
 
 // Action creator for the SET_GAME_ID action type.
 export function setGameID(id: string): GameActionTypes {
@@ -13,5 +18,13 @@ export function setIsCreated(isCreated: boolean): GameActionTypes {
   return {
     type: SET_IS_CREATED,
     payload: isCreated,
+  };
+}
+
+// Action creator for the SET_IS_JOINED action type.
+export function setIsJoined(isJoined: boolean): GameActionTypes {
+  return {
+    type: SET_IS_JOINED,
+    payload: isJoined,
   };
 }

--- a/client/src/store/game/reducers.ts
+++ b/client/src/store/game/reducers.ts
@@ -3,11 +3,13 @@ import {
   GameActionTypes,
   SET_GAME_ID,
   SET_IS_CREATED,
+  SET_IS_JOINED,
 } from './types';
 
 const initialState: GameState = {
   id: '',
   isCreated: false,
+  isJoined: false,
 };
 
 export default function gameReducer(
@@ -24,6 +26,11 @@ export default function gameReducer(
       return {
         ...state,
         isCreated: action.payload,
+      };
+    case SET_IS_JOINED:
+      return {
+        ...state,
+        isJoined: action.payload,
       };
     default:
       return state;

--- a/client/src/store/game/types.ts
+++ b/client/src/store/game/types.ts
@@ -1,6 +1,7 @@
 export interface GameState {
   id: string;
   isCreated: boolean;
+  isJoined: boolean;
 }
 
 export const SET_GAME_ID = 'SET_GAME_ID';
@@ -13,4 +14,12 @@ interface SetIsCreatedAction {
   type: typeof SET_IS_CREATED;
   payload: boolean;
 }
-export type GameActionTypes = SetGameIDAction | SetIsCreatedAction;
+export const SET_IS_JOINED = 'SET_IS_JOINED';
+interface SetIsJoinedAction {
+  type: typeof SET_IS_JOINED;
+  payload: boolean;
+}
+export type GameActionTypes =
+  | SetGameIDAction
+  | SetIsCreatedAction
+  | SetIsJoinedAction;

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,10 +1,12 @@
 import { combineReducers, createStore } from 'redux';
 import gameReducer from './game/reducers';
 import userReducer from './user/reducers';
+import boardReducer from './board/reducers';
 
 const rootReducer = combineReducers({
   game: gameReducer,
   user: userReducer,
+  board: boardReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;


### PR DESCRIPTION
This PR introduces some rough ideas for what the `BoardScreen` may look like. It also sets up a new `board` object in the global Redux store (although not all of the fields that I expect to be in that object come release day have been fleshed out in this PR).

<img width="1552" alt="Screen Shot 2020-07-31 at 9 35 37 PM" src="https://user-images.githubusercontent.com/31291920/89091252-3363c680-d376-11ea-8f1c-efffa6c8270d.png">
