### PR TITLE
Create "set display name" screen, and allow users to change their display name

### DIFF
--- a/client/src/components/DisplayName.css
+++ b/client/src/components/DisplayName.css
@@ -1,3 +1,7 @@
+#display-name-container {
+  margin: 2rem 0rem;
+}
+
 #emph-display-name {
   font-weight: bold;
 }

--- a/client/src/components/DisplayName.tsx
+++ b/client/src/components/DisplayName.tsx
@@ -7,21 +7,35 @@ import React from 'react';
 import './DisplayName.css';
 import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from '../store';
+import { setIsSettingDisplayName } from '../store/user/actions';
 
 // Redux business.
+
 const mapState = (state: RootState) => ({
   displayName: state.user.displayName,
 });
-const connector = connect(mapState);
+const mapDispatch = {
+  setIsSettingDisplayName: (isSettingDisplayName: boolean) =>
+    setIsSettingDisplayName(isSettingDisplayName),
+};
+const connector = connect(mapState, mapDispatch);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 // Component.
 
 const DisplayName: React.FC<PropsFromRedux> = (props: PropsFromRedux) => {
   return (
-    <p>
-      Display name: <span id="emph-display-name">{props.displayName}</span>
-    </p>
+    <div id="display-name-container">
+      <p>
+        Display name: <span id="emph-display-name">{props.displayName}</span>
+      </p>
+      <button
+        className="secondary-btn"
+        type="button"
+        onClick={() => props.setIsSettingDisplayName(true)}>
+        Change Display Name
+      </button>
+    </div>
   );
 };
 

--- a/client/src/screens/CreateGameScreen.tsx
+++ b/client/src/screens/CreateGameScreen.tsx
@@ -4,43 +4,50 @@ import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from '../store';
 import DisplayName from '../components/DisplayName';
 import TeamMembersList from '../components/TeamMembersList';
+import SetDisplayNameScreen from './SetDisplayNameScreen';
 
 // Redux business.
 
 const mapState = (state: RootState) => ({
   gameID: state.game.id,
+  isSettingDisplayName: state.user.isSettingDisplayName,
 });
 const connector = connect(mapState);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 // Component.
 
-const CreateGameScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => (
-  <div className="container centered-container">
-    <div className="card">
-      <div className="even-columns">
-        <div>
-          <h1>Create a New Game</h1>
-          <h3>{props.gameID.toUpperCase()}</h3>
-          <DisplayName />
-          <button className="secondary-btn" type="button">
-            Join Red Team
-          </button>
-          <button className="secondary-btn" type="button">
-            Join Blue Team
-          </button>
-          <button className="secondary-btn" type="button">
-            Change Some Other Setting
-          </button>
-          <button className="primary-btn" id="create-game-btn" type="button">
-            Create Game
-          </button>
+const CreateGameScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => {
+  if (props.isSettingDisplayName) {
+    return <SetDisplayNameScreen />;
+  }
+  return (
+    <div className="container centered-container">
+      <div className="card">
+        <div className="even-columns">
+          <div>
+            <h1>Create a New Game</h1>
+            <h3>{props.gameID.toUpperCase()}</h3>
+            <DisplayName />
+            <button className="secondary-btn" type="button">
+              Join Red Team
+            </button>
+            <button className="secondary-btn" type="button">
+              Join Blue Team
+            </button>
+            <button className="secondary-btn" type="button">
+              Change Some Other Setting
+            </button>
+            <button className="primary-btn" id="create-game-btn" type="button">
+              Create Game
+            </button>
+          </div>
+          <TeamMembersList title="Red Team" />
+          <TeamMembersList title="Blue Team" />
         </div>
-        <TeamMembersList title="Red Team" />
-        <TeamMembersList title="Blue Team" />
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default connector(CreateGameScreen);

--- a/client/src/screens/JoinGameScreen.tsx
+++ b/client/src/screens/JoinGameScreen.tsx
@@ -3,43 +3,50 @@ import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from '../store';
 import DisplayName from '../components/DisplayName';
 import TeamMembersList from '../components/TeamMembersList';
+import SetDisplayNameScreen from './SetDisplayNameScreen';
 
 // Redux business.
 
 const mapState = (state: RootState) => ({
   gameID: state.game.id,
+  isSettingDisplayName: state.user.isSettingDisplayName,
 });
 const connector = connect(mapState);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 // Component.
 
-const JoinGameScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => (
-  <div className="container centered-container">
-    <div className="card">
-      <div className="even-columns">
-        <div>
-          <h1>Join an Ongoing Game</h1>
-          <h3>{props.gameID.toUpperCase()}</h3>
-          <DisplayName />
-          <button className="secondary-btn" type="button">
-            Join Red Team
-          </button>
-          <button className="secondary-btn" type="button">
-            Join Blue Team
-          </button>
-          <button className="secondary-btn" type="button">
-            Change Some Other Setting
-          </button>
-          <button className="primary-btn" id="create-game-btn" type="button">
-            Join Game
-          </button>
+const JoinGameScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => {
+  if (props.isSettingDisplayName) {
+    return <SetDisplayNameScreen />;
+  }
+  return (
+    <div className="container centered-container">
+      <div className="card">
+        <div className="even-columns">
+          <div>
+            <h1>Join an Ongoing Game</h1>
+            <h3>{props.gameID.toUpperCase()}</h3>
+            <DisplayName />
+            <button className="secondary-btn" type="button">
+              Join Red Team
+            </button>
+            <button className="secondary-btn" type="button">
+              Join Blue Team
+            </button>
+            <button className="secondary-btn" type="button">
+              Change Some Other Setting
+            </button>
+            <button className="primary-btn" id="create-game-btn" type="button">
+              Join Game
+            </button>
+          </div>
+          <TeamMembersList title="Red Team" />
+          <TeamMembersList title="Blue Team" />
         </div>
-        <TeamMembersList title="Red Team" />
-        <TeamMembersList title="Blue Team" />
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default connector(JoinGameScreen);

--- a/client/src/screens/SetDisplayNameScreen.tsx
+++ b/client/src/screens/SetDisplayNameScreen.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+import { RootState } from '../store';
+import setDisplayName from '../store/user/actions';
+
+// Redux business.
+
+const mapState = (state: RootState) => ({
+  displayName: state.user.displayName,
+});
+const mapDispatch = {
+  setDisplayName: (displayName: string) => setDisplayName(displayName),
+};
+const connector = connect(mapState, mapDispatch);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+// Component.
+
+const SetDisplayNameScreen: React.FC<PropsFromRedux> = (
+  props: PropsFromRedux,
+) => {
+  const [newDisplayName, setNewDisplayName] = useState(props.displayName);
+
+  const handleDisplayNameFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    props.setDisplayName(newDisplayName);
+  };
+
+  return (
+    <div className="container centered-container">
+      <div className="card card-sm">
+        <h1>Set Display Name</h1>
+        <p>
+          Your display name is like your username. Other players will see this.
+        </p>
+        <div id="form-sm-wrapper">
+          <form
+            className="form-sm"
+            onSubmit={(e) => handleDisplayNameFormSubmit(e)}>
+            <input
+              autoFocus
+              type="text"
+              value={newDisplayName}
+              placeholder="Enter a display name"
+              onChange={(e) => setNewDisplayName(e.target.value)}
+            />
+            <button className="primary-btn" type="submit">
+              Set
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default connector(SetDisplayNameScreen);

--- a/client/src/screens/SetDisplayNameScreen.tsx
+++ b/client/src/screens/SetDisplayNameScreen.tsx
@@ -1,15 +1,18 @@
 import React, { useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from '../store';
-import setDisplayName from '../store/user/actions';
+import { setDisplayName, setIsSettingDisplayName } from '../store/user/actions';
 
 // Redux business.
 
 const mapState = (state: RootState) => ({
   displayName: state.user.displayName,
+  isSettingDisplayName: state.user.isSettingDisplayName,
 });
 const mapDispatch = {
   setDisplayName: (displayName: string) => setDisplayName(displayName),
+  setIsSettingDisplayName: (isSettingDisplayName: boolean) =>
+    setIsSettingDisplayName(isSettingDisplayName),
 };
 const connector = connect(mapState, mapDispatch);
 type PropsFromRedux = ConnectedProps<typeof connector>;
@@ -24,6 +27,7 @@ const SetDisplayNameScreen: React.FC<PropsFromRedux> = (
   const handleDisplayNameFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     props.setDisplayName(newDisplayName);
+    props.setIsSettingDisplayName(false);
   };
 
   return (

--- a/client/src/store/user/actions.ts
+++ b/client/src/store/user/actions.ts
@@ -1,9 +1,23 @@
-import { UserActionTypes, SET_DISPLAY_NAME } from './types';
+import {
+  UserActionTypes,
+  SET_DISPLAY_NAME,
+  SET_IS_SETTING_DISPLAY_NAME,
+} from './types';
 
 // Action creator for the SET_DISPLAY_NAME action type.
-export default function setDisplayName(displayName: string): UserActionTypes {
+export function setDisplayName(displayName: string): UserActionTypes {
   return {
     type: SET_DISPLAY_NAME,
     payload: displayName,
+  };
+}
+
+// Action creator for the SET_IS_SETTING_DISPLAY_NAME action type.
+export function setIsSettingDisplayName(
+  isSettingDisplayName: boolean,
+): UserActionTypes {
+  return {
+    type: SET_IS_SETTING_DISPLAY_NAME,
+    payload: isSettingDisplayName,
   };
 }

--- a/client/src/store/user/reducers.ts
+++ b/client/src/store/user/reducers.ts
@@ -1,7 +1,13 @@
-import { UserState, UserActionTypes, SET_DISPLAY_NAME } from './types';
+import {
+  UserState,
+  UserActionTypes,
+  SET_DISPLAY_NAME,
+  SET_IS_SETTING_DISPLAY_NAME,
+} from './types';
 
 const initialState: UserState = {
   displayName: '',
+  isSettingDisplayName: true,
 };
 
 export default function userReducer(
@@ -13,6 +19,11 @@ export default function userReducer(
       return {
         ...state,
         displayName: action.payload,
+      };
+    case SET_IS_SETTING_DISPLAY_NAME:
+      return {
+        ...state,
+        isSettingDisplayName: action.payload,
       };
     default:
       return state;

--- a/client/src/store/user/types.ts
+++ b/client/src/store/user/types.ts
@@ -1,10 +1,18 @@
 export interface UserState {
   displayName: string;
+  isSettingDisplayName: boolean;
 }
 
-export const SET_DISPLAY_NAME = 'SET_DISPLAY_NAME ';
+export const SET_DISPLAY_NAME = 'SET_DISPLAY_NAME';
 interface SetDisplayNameAction {
   type: typeof SET_DISPLAY_NAME;
   payload: string;
 }
-export type UserActionTypes = SetDisplayNameAction;
+export const SET_IS_SETTING_DISPLAY_NAME = 'SET_IS_SETTING_DISPLAY_NAME';
+interface SetIsSettingDisplayNameAction {
+  type: typeof SET_IS_SETTING_DISPLAY_NAME;
+  payload: boolean;
+}
+export type UserActionTypes =
+  | SetDisplayNameAction
+  | SetIsSettingDisplayNameAction;


### PR DESCRIPTION
This PR proposes to let users set their display names, and change them as many times as they want before starting a game or joining an ongoing one.

When users first visit a `/:gameID` URL, a new "set display name" screen will appear. Before the game begins, or before they join an ongoing game, users can summon that screen again with a "Change Display Name" button.

Display names, along with whether or not a user is setting/changing their display name currently, is stored in the `user` section of the Redux global state object.

<img width="1552" alt="Screen Shot 2020-08-04 at 3 41 45 PM" src="https://user-images.githubusercontent.com/31291920/89337875-b3857700-d669-11ea-8a1a-f14cf5b9fda8.png">
<img width="1552" alt="Screen Shot 2020-08-04 at 3 42 10 PM" src="https://user-images.githubusercontent.com/31291920/89337898-b97b5800-d669-11ea-8759-9c5a3115acec.png">
