### PR TITLE
Bring in github.com/gorilla/mux for routing

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -1,3 +1,5 @@
 module github.com/nchaloult/codenames
 
 go 1.14
+
+require github.com/gorilla/mux v1.7.4 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=


### PR DESCRIPTION
To make creating more powerful routes easier, this PR proposes to bring in [gorilla's mux](https://github.com/gorilla/mux) package. In the past, I've used lighter routing libraries like [httprouter](https://github.com/julienschmidt/httprouter) or just the standard library, but in this case, mux makes it easy to serve a single page application with its own routes.

The `spaHandler` interface that this PR introduces comes from [mux's documentation](https://github.com/gorilla/mux#serving-single-page-applications).