### PR TITLE
Prepare for firebase deployment

### DIFF
--- a/client/.firebaserc
+++ b/client/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "codenames-frontend"
+  }
+}

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,3 +1,6 @@
+# firebase cache
+/.firebase
+
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies

--- a/client/firebase.json
+++ b/client/firebase.json
@@ -1,0 +1,16 @@
+{
+  "hosting": {
+    "public": "build",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "deploy": "yarn build && firebase deploy"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
This PR proposes to tie the front-end app to a firebase project.

I ran `$ firebase init` to create the necessary files to get the `client/` project ready for deployment with firebase hosting. This PR also introduces a new `deploy` script in `package.json` to deploy any changes to firebase in the future.