### PR TITLE
Decouple client and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,39 @@
 
 Bringing a popular board game online that you can play in real time with your friends
 
-## Launching with Docker
+## Developing Locally
 
-Build an image that mirrors our production environment, and spin up a container from that image.
+After cloning this repo, get everything ready to go:
 
+    $ cd codenames/client && yarn
+
+Then in one shell, spin up the server:
+
+    $ cd server
+    $ go run *.go
+
+Or if you're hungry for speed, you can:
+
+    $ go build && ./codenames
+
+And in another shell, spin up the React app:
+
+    $ cd client
+    $ yarn start
+
+## Deploying to Production
+
+The following steps are reminders for myself more than anything. If you'd like to deploy your own version of this project, though, it shouldn't be difficult to adapt these steps to better fit your situation.
+
+### Server
+
+The server is "containerized," so you may deploy it through whichever cloud service provider that you're comfortable with, pretty much. I've chosen Heroku because of it's great free-tier plan.
+
+If you'd like, you may test out how your changes to the server behave in a production environment by running:
+
+    $ cd server
     $ docker build -t codenames .
-    $ docker run --rm --name codenames -p 3000:6969 -d codenames
-
-Now, test things out by either visiting `localhost:3000` in a browser, or hitting HTTP API endpoints at `localhost:3000/api`. For instance:
-
-    $ curl localhost:3000/api/hello
-
-When you're done, spin everything down.
-
-    $ docker stop codenames
-
-## Deploying to Production on Heroku
-
-Build a new image with your most recent changes/additions.
-
-    $ docker build -t codenames .
+    $ docker run --rm --name codenames -p 6969:6969 -d codenames
 
 Deploy your changes to Heroku. These steps assume that you've already installed the Heroku CLI on your machine, logged into your Heroku account through the CLI, and created a Heroku app named "codenames".
 
@@ -34,3 +47,12 @@ Deploy your changes to Heroku. These steps assume that you've already installed 
 To check on the status of things, you can view your production deployment's logs.
 
     $ heroku logs -t -a codenames
+
+### Client
+
+I've deployed the front-end web application with Firebase Hosting. The steps below assume that you've already installed the Firebase CLI on your machine, logged into your Google account through the CLI, created a new Firebase project, and tied this repo to it with `firebase init`.
+
+Invoke the `deploy` script that's defined in in `package.json` to push up your changes/additions by running:
+
+    $ cd client
+    $ yarn deploy

--- a/client/.firebaserc
+++ b/client/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "codenames-frontend"
+  }
+}

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,3 +1,6 @@
+# firebase cache
+/.firebase
+
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies

--- a/client/firebase.json
+++ b/client/firebase.json
@@ -1,0 +1,16 @@
+{
+  "hosting": {
+    "public": "build",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "deploy": "yarn build && firebase deploy"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/server/server.go
+++ b/server/server.go
@@ -57,13 +57,6 @@ func (s *Server) Start() {
 		os.Exit(0)
 	}()
 
-	// Serve the static files from the production build of our web front-end.
-	//
-	// A directory named "front-end" doesn't exist in this repo, but one does
-	// exist in the container that we deploy to production. See this repo's
-	// Dockerfile.
-	http.Handle("/", http.FileServer(http.Dir("./front-end")))
-
 	// Register routes with their corresponding handler funcs.
 	http.HandleFunc("/api/hello", s.helloHandler)
 


### PR DESCRIPTION
Previously, static files from the production build of the front-end were being served by the server. The idea behind this approach was that production deployments of Codenames would be easy: the client and the server could both be bundled up into a Docker image, and a container could be deployed through my favorite cloud service provider. Because the front-end application has its own routes (with React Router), and the server wants to define its own routes, too (for API endpoints), doing that is complicated.

It makes more sense to stand up the front-end and back-end on separate web servers. This PR proposes to decouple the client and server by tweaking the `Dockerfile` and `.dockerignore` to only package up the server, and by writing Firebase config files that wire up the client to a firebase hosting project.