### PR TITLE
Create Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+dev: # Default target. Spins up back-end and front-end
+	make -j 2 runf runb
+
+# Client targets
+
+runf: # Run front-end
+	cd client && yarn start
+
+buildf: # Build front-end for production
+	cd client && yarn build
+
+# Server targets
+
+runb: # Run back-end
+	cd server && go run *.go
+
+buildb: # Build back-end with docker
+	cd server && docker build -t codenames .
+
+testb: buildb # Test back-end in a production environment
+	docker run --rm --name codenames -p 6969:6969 -d codenames
+
+stoptestb: # Spin down docker container
+	docker stop codenames
+
+# Deploy targets
+
+deployf: buildf # Deploy front-end to Firebase
+	cd client && firebase deploy
+
+deployb: # Deploy back-end to Heroku
+	heroku container:push web -a codenames && \
+	heroku container:release web -a codenames
+
+deployboth: # Deploy both the back-end and the front-end
+	deployf && deployb
+
+deploylogs: # Check logs of back-end container in production
+	heroku logs -t -a codenames

--- a/README.md
+++ b/README.md
@@ -7,27 +7,17 @@ Bringing a popular board game online that you can play in real time with your fr
 
 ## Developing Locally
 
-After cloning this repo, get everything ready to go:
+Spin up both the server and the client with the default target in `Makefile`:
 
-    $ cd codenames/client && yarn
+    $ make
 
-Then in one shell, spin up the server:
+If you've just cloned this repo, then you'll first need to install dependencies that the front-end needs:
 
-    $ cd server
-    $ go run *.go
-
-Or if you're hungry for speed, you can:
-
-    $ go build && ./codenames
-
-And in another shell, spin up the React app:
-
-    $ cd client
-    $ yarn start
+    $ cd client && yarn
 
 ## Deploying to Production
 
-The following steps are reminders for myself more than anything. If you'd like to deploy your own version of this project, though, it shouldn't be difficult to adapt these steps to better fit your situation.
+The following steps are reminders for myself more than anything. If you'd like to deploy your own version of this project, though, it shouldn't be difficult to adapt these steps, or make changes in `Makefile`, to better fit your situation.
 
 ### Server
 
@@ -35,24 +25,20 @@ The server is "containerized," so you may deploy it through whichever cloud serv
 
 If you'd like, you may test out how your changes to the server behave in a production environment by running:
 
-    $ cd server
-    $ docker build -t codenames .
-    $ docker run --rm --name codenames -p 6969:6969 -d codenames
+    $ make testb
 
-Deploy your changes to Heroku. These steps assume that you've already installed the Heroku CLI on your machine, logged into your Heroku account through the CLI, and created a Heroku app named "codenames".
+If everything looks good, deploy your changes to Heroku. This step assumes that you've already installed the Heroku CLI on your machine, logged into your Heroku account through the CLI, and created a Heroku app named "codenames".
 
-    $ heroku container:push web -a codenames
-    $ heroku container:release web -a codenames
+    $ make deployb
 
-To check on the status of things, you can view your production deployment's logs.
+To check on the status of things, you can view your production deployment's log messages in real time:
 
-    $ heroku logs -t -a codenames
+    $ make deploylogs
 
 ### Client
 
 I've deployed the front-end web application with Firebase Hosting. The steps below assume that you've already installed the Firebase CLI on your machine, logged into your Google account through the CLI, created a new Firebase project, and tied this repo to it with `firebase init`.
 
-Invoke the `deploy` script that's defined in in `package.json` to push up your changes/additions by running:
+Push your changes/additions up to Firebase by running:
 
-    $ cd client
-    $ yarn deploy
+    $ make deployf


### PR DESCRIPTION
This PR proposes to introduce a Makefile with targets for common tasks like spinning up the client and the server locally, and uncommon tasks like deploying changes on the client and/or the server to production. It makes local development easier (just have to run `$ make` instead of opening one shell to run the client in and another to run the server in), and it also creates helpful aliases for commands that I struggle to remember.