### PR TITLE
Stand up server infrastructure to support multiple clients and games

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
+	github.com/gorilla/websocket v1.4.2
 )

--- a/server/go.mod
+++ b/server/go.mod
@@ -3,7 +3,6 @@ module github.com/nchaloult/codenames
 go 1.14
 
 require (
-	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.2
 )

--- a/server/go.mod
+++ b/server/go.mod
@@ -2,4 +2,7 @@ module github.com/nchaloult/codenames
 
 go 1.14
 
-require github.com/gorilla/mux v1.7.4
+require (
+	github.com/google/uuid v1.1.1
+	github.com/gorilla/mux v1.7.4
+)

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,2 +1,4 @@
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/server/go.sum
+++ b/server/go.sum
@@ -2,3 +2,5 @@ github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,5 +1,3 @@
-github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
-github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/server/model/player.go
+++ b/server/model/player.go
@@ -1,14 +1,19 @@
 package model
 
-// Player stores information about a player in a Game. Players are managed by
+import "github.com/gorilla/websocket"
+
+// Player stores information about a player in a Game, as well as the Websocket
+// connection that they're connected to the server with. Players are managed by
 // an Interactor.
 type Player struct {
+	Conn        *websocket.Conn
 	DisplayName string
 	IsOnRedTeam bool
 	IsSpymaster bool
 }
 
 // NewPlayer returns a pointer to a new Player object with initialized fields.
-func NewPlayer(displayName string, isOnRedTeam, isSpymaster bool) *Player {
-	return &Player{displayName, isOnRedTeam, isSpymaster}
+// Sets IsOnRedTeam to true and IsSpymaster to false by default.
+func NewPlayer(conn *websocket.Conn, displayName string) *Player {
+	return &Player{conn, displayName, true, false}
 }

--- a/server/model/player.go
+++ b/server/model/player.go
@@ -1,0 +1,14 @@
+package model
+
+// Player stores information about a player in a Game. Players are managed by
+// an Interactor.
+type Player struct {
+	DisplayName string
+	IsOnRedTeam bool
+	IsSpymaster bool
+}
+
+// NewPlayer returns a pointer to a new Player object with initialized fields.
+func NewPlayer(displayName string, isOnRedTeam, isSpymaster bool) *Player {
+	return &Player{displayName, isOnRedTeam, isSpymaster}
+}

--- a/server/realtime/interactor.go
+++ b/server/realtime/interactor.go
@@ -1,7 +1,6 @@
 package realtime
 
 import (
-	"github.com/google/uuid"
 	"github.com/nchaloult/codenames/model"
 )
 
@@ -20,8 +19,11 @@ import (
 // Interactor and Game have a 1-1 relationship; there is one Interactor instance
 // associated with, or responsible for, each Game.
 type Interactor struct {
-	Game    *model.Game
-	Players map[uuid.UUID]*model.Player
+	Game *model.Game
+
+	// Players stores Player objects for each active client, indexed by their
+	// display name.
+	Players map[string]*model.Player
 }
 
 // NewInteractor returns a pointer to a new Interactor object initialized with
@@ -29,6 +31,6 @@ type Interactor struct {
 func NewInteractor(game *model.Game) *Interactor {
 	return &Interactor{
 		Game:    game,
-		Players: make(map[uuid.UUID]*model.Player, 0),
+		Players: make(map[string]*model.Player, 0),
 	}
 }

--- a/server/realtime/interactor.go
+++ b/server/realtime/interactor.go
@@ -4,12 +4,6 @@ import (
 	"github.com/nchaloult/codenames/model"
 )
 
-// Interactor facilitates events through a Websocket connection with clients.
-// Each Interactor instance is associated with a Game instance; they have a 1-1
-// relationship. Whenever a client performs an action that triggers an event,
-// an Interactor instance processes that
-// Players/connected clients.
-
 // Interactor manages Players that are playing in a Game, and facilitates events
 // through Websocket connections with all of those Players. When a Player
 // performs an action that triggers an event, whether that action be in an

--- a/server/realtime/interactor.go
+++ b/server/realtime/interactor.go
@@ -1,0 +1,34 @@
+package realtime
+
+import (
+	"github.com/google/uuid"
+	"github.com/nchaloult/codenames/model"
+)
+
+// Interactor facilitates events through a Websocket connection with clients.
+// Each Interactor instance is associated with a Game instance; they have a 1-1
+// relationship. Whenever a client performs an action that triggers an event,
+// an Interactor instance processes that
+// Players/connected clients.
+
+// Interactor manages Players that are playing in a Game, and facilitates events
+// through Websocket connections with all of those Players. When a Player
+// performs an action that triggers an event, whether that action be in an
+// ongoing game or a game lobby, an Interactor processes that event by mutating
+// the data model and notifying all other Players.
+//
+// Interactor and Game have a 1-1 relationship; there is one Interactor instance
+// associated with, or responsible for, each Game.
+type Interactor struct {
+	Game    *model.Game
+	Players map[uuid.UUID]model.Player
+}
+
+// NewInteractor returns a pointer to a new Interactor object initialized with
+// the provided game.
+func NewInteractor(game *model.Game) *Interactor {
+	return &Interactor{
+		Game:    game,
+		Players: make(map[uuid.UUID]model.Player, 0),
+	}
+}

--- a/server/realtime/interactor.go
+++ b/server/realtime/interactor.go
@@ -21,7 +21,7 @@ import (
 // associated with, or responsible for, each Game.
 type Interactor struct {
 	Game    *model.Game
-	Players map[uuid.UUID]model.Player
+	Players map[uuid.UUID]*model.Player
 }
 
 // NewInteractor returns a pointer to a new Interactor object initialized with
@@ -29,6 +29,6 @@ type Interactor struct {
 func NewInteractor(game *model.Game) *Interactor {
 	return &Interactor{
 		Game:    game,
-		Players: make(map[uuid.UUID]model.Player, 0),
+		Players: make(map[uuid.UUID]*model.Player, 0),
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -71,7 +71,7 @@ func (s *Server) Start() {
 	router := mux.NewRouter()
 
 	// Register routes with their corresponding handler funcs.
-	router.HandleFunc("/health", s.healthHandler).Methods("GET")
+	router.HandleFunc("/health", s.healthHandler).Methods(http.MethodGet)
 	router.HandleFunc("/ws", s.wsHandler)
 
 	// Stand up the server.

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/gorilla/mux"
+	"github.com/nchaloult/codenames/realtime"
 )
 
 const (
@@ -22,6 +23,10 @@ const (
 type Server struct {
 	// port is the port number that an HTTP server will listen for requests on.
 	port int
+
+	// activeGames stores pointers to Interactors for all ongoing games that the
+	// server is handling.
+	activeGames map[string]*realtime.Interactor
 }
 
 // NewServer returns a pointer to a new Server object that's configured with the
@@ -36,7 +41,8 @@ func NewServer(port int) (*Server, error) {
 	}
 
 	return &Server{
-		port,
+		port:        port,
+		activeGames: make(map[string]*realtime.Interactor, 0),
 	}, nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -9,7 +9,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+	"github.com/nchaloult/codenames/model"
 	"github.com/nchaloult/codenames/realtime"
 )
 
@@ -70,6 +73,7 @@ func (s *Server) Start() {
 
 	// Register routes with their corresponding handler funcs.
 	router.HandleFunc("/health", s.healthHandler).Methods("GET")
+	router.HandleFunc("/ws", s.wsHandler).Methods(http.MethodPost)
 
 	// Stand up the server.
 	log.Printf("Listening on port %d....\n", s.port)
@@ -89,6 +93,65 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	err := json.NewEncoder(w).Encode(response)
+	if err != nil {
+		errCode := http.StatusInternalServerError
+		errMsg := fmt.Sprintf("Failed to encode response as JSON: %v\n", err)
+		http.Error(w, errMsg, errCode)
+		return
+	}
+}
+
+// wsRequestBody represents the structure of JSON bodies in POST requests to
+// the /ws route.
+type wsRequestBody struct {
+	gameID      string
+	displayName string
+}
+
+// wsHandler serves POST requests at the /ws route. Creates a new game (or adds
+// a new player to the existing game that corresponds with the provided gameID),
+// and attempts to establish a Websocket connection with a client.
+func (s *Server) wsHandler(w http.ResponseWriter, r *http.Request) {
+	// Extract info from request body.
+	var reqBody wsRequestBody
+	err := json.NewDecoder(r.Body).Decode(&reqBody)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Look for an active game associated with the provided gameID. If one
+	// doesn't exist, then create a new one.
+	if _, ok := s.activeGames[reqBody.gameID]; !ok {
+		// TODO: Write function somewhere in model package to randomly generate
+		// a dictionary. For now, I'm just using a dummy/stubbed one.
+		dictionary := [25]string{"foo", "bar", "baz"}
+		newGame := model.NewGame(dictionary)
+		newInteractor := realtime.NewInteractor(newGame)
+		s.activeGames[reqBody.gameID] = newInteractor
+	}
+
+	// Attempt to establish a websocket connection with the server.
+	upgrader := websocket.Upgrader{}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to upgrade to a websocket connection: %v",
+			err)
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	// Create a new player for our connected client.
+	newPlayer := model.NewPlayer(conn, reqBody.displayName)
+	newPlayerUUID := uuid.New()
+	s.activeGames[reqBody.gameID].Players[newPlayerUUID] = newPlayer
+
+	// Let the client know about the new UUID we just generated for it.
+	response := map[string]interface{}{
+		"uuid": newPlayerUUID,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
 		errCode := http.StatusInternalServerError
 		errMsg := fmt.Sprintf("Failed to encode response as JSON: %v\n", err)

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,7 @@ type Server struct {
 	port int
 
 	// activeGames stores pointers to Interactors for all ongoing games that the
-	// server is handling.
+	// server is handling, indexed by gameIDs.
 	activeGames map[string]*realtime.Interactor
 }
 
@@ -113,7 +113,6 @@ type wsRequestBody struct {
 // and "displayName" as query parameters when the /ws endpoint is hit.
 func (s *Server) wsHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract info from query params.
-	// TODO: introduce error handling if
 	queryParams := r.URL.Query()
 	if _, ok := queryParams["gameID"]; !ok {
 		errMsg := fmt.Sprint("the \"gameID\" query param is required")


### PR DESCRIPTION
Related to #7 

This PR proposes to introduce `GameInteractor`, a middle-man between clients and the underlying data model of ongoing games. `GameInteractor`s will sit between a `Game` object and a collection of `Player`s, or clients, who are participating in that game. Whenever a client performs an action or triggers an event, a `GameInteractor` will process that event by appropriately manipulating the data model (a `Game` object's state), and notifying all other `Player`s over Websocket connections.

This PR also adds a new `/ws` route, or HTTP endpoint. Clients will hit this endpoint when they're trying to create a new game or join an ongoing one. This endpoint's handler is responsible for creating a new `Game` and `GameInteractor` if a game with the provided `gameID` doesn't already exist, and establishing a Websocket connection between that client and a `GameInteractor`.

All of the functionality that `GameInteractor`s will ultimately be responsible for is not implemented in this PR. This is really more about setting up the scaffolding for this middle-man to exist, and is one step in the process of wiring the front-end up to this and seeing if clients can successfully manipulate a `Game` through one of these `GameInteractor`s.