### PR TITLE
Add travis.yml for running server tests

### DIFF
--- a/server/.travis.yml
+++ b/server/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+
+go:
+  - 1.14.x


### PR DESCRIPTION
I've been running into problems with Github Actions not being able to import or install my own packages. See some [failed builds](https://github.com/nchaloult/codenames/runs/959616299?check_suite_focus=true). I've looked into resolving this issue, but have come up empty for now.

In the meantime, I'd like to try and get a CI pipeline stood up with [Travis](https://travis-ci.org). I've had good experiences with this service in the past.

It might get tricky to tell Travis that the entire repo isn't a Go project, and that it'll only need to pay attention to the `server/` directory. If I can't wire everything up correctly and get that working, then I'll most likely just revert this change.