### PR TITLE
Revert "Add travis.yml for running server tests"

### DIFF
--- a/server/.travis.yml
+++ b/server/.travis.yml
@@ -1,4 +1,0 @@
-language: go
-
-go:
-  - 1.14.x


### PR DESCRIPTION
Reverts nchaloult/codenames#28

I struggled to find any documentation about telling Travis to only build a specific directory in your repo. I found [these](https://docs.travis-ci.com/user/customizing-the-build) [resources](https://stackoverflow.com/questions/14468464/how-to-specify-a-build-folder-in-travis), but they didn't have what I was looking for, and I'm not sure where else to look.