### PR TITLE
Establish a Websocket connection between a client and the server

### DIFF
--- a/client/src/screens/CreateGameScreen.tsx
+++ b/client/src/screens/CreateGameScreen.tsx
@@ -17,7 +17,13 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 
 // Component.
 
-const CreateGameScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => {
+interface ComponentProps {
+  temp: string;
+}
+
+type Props = PropsFromRedux & ComponentProps;
+
+const CreateGameScreen: React.FC<Props> = (props: Props) => {
   if (props.isSettingDisplayName) {
     return <SetDisplayNameScreen />;
   }
@@ -28,6 +34,7 @@ const CreateGameScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => {
           <div>
             <h1>Create a New Game</h1>
             <h3>{props.gameID.toUpperCase()}</h3>
+            <h4>{props.temp}</h4>
             <DisplayName />
             <button className="secondary-btn" type="button">
               Join Red Team

--- a/client/src/screens/CreateGameScreen.tsx
+++ b/client/src/screens/CreateGameScreen.tsx
@@ -17,13 +17,7 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 
 // Component.
 
-interface ComponentProps {
-  temp: string;
-}
-
-type Props = PropsFromRedux & ComponentProps;
-
-const CreateGameScreen: React.FC<Props> = (props: Props) => {
+const CreateGameScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => {
   if (props.isSettingDisplayName) {
     return <SetDisplayNameScreen />;
   }
@@ -34,7 +28,6 @@ const CreateGameScreen: React.FC<Props> = (props: Props) => {
           <div>
             <h1>Create a New Game</h1>
             <h3>{props.gameID.toUpperCase()}</h3>
-            <h4>{props.temp}</h4>
             <DisplayName />
             <button className="secondary-btn" type="button">
               Join Red Team

--- a/client/src/screens/GameScreen.tsx
+++ b/client/src/screens/GameScreen.tsx
@@ -38,7 +38,6 @@ type Props = PropsFromRedux & RouteComponentProps<any>;
 
 const GameScreen: React.FC<Props> = (props: Props) => {
   const [isLoading, setIsLoading] = useState(true);
-  const [temporary, setTemporary] = useState('placeholder');
 
   useEffect(() => {
     const gameIDFromURL: string = props.match.params.gameID;
@@ -49,11 +48,6 @@ const GameScreen: React.FC<Props> = (props: Props) => {
     const socketURL = `${protocol}${SERVER_URL}/ws?gameID=${gameIDFromURL}`;
     const socket = new WebSocket(socketURL);
     socket.onopen = () => setSocket(socket);
-
-    // Temporary!
-    // TODO: remove this! Just testing to see if I can send messages between a
-    // client and the server through a Websocket.
-    socket.onmessage = (event) => setTemporary(JSON.parse(event.data).id);
 
     // For now, just stub this out & pretend that the server told us that a game
     // with the provided ID doesn't exist, therefore we'll be creating a new
@@ -81,7 +75,7 @@ const GameScreen: React.FC<Props> = (props: Props) => {
   if (props.isCreated) {
     return <JoinGameScreen />;
   }
-  return <CreateGameScreen temp={temporary} />;
+  return <CreateGameScreen />;
 };
 
 export default connector(GameScreen);

--- a/client/src/screens/GameScreen.tsx
+++ b/client/src/screens/GameScreen.tsx
@@ -7,6 +7,9 @@ import Loading from '../components/Loading';
 import CreateGameScreen from './CreateGameScreen';
 import BoardScreen from './BoardScreen';
 import JoinGameScreen from './JoinGameScreen';
+import { setUserID } from '../store/user/actions';
+import setSocket from '../store/websocket/actions';
+import { SERVER_URL } from '../store/constants';
 
 // In this component, a Websocket connection is established with the server.
 // Depending on whether the game with the provided gameID has already been
@@ -20,9 +23,11 @@ const mapState = (state: RootState) => ({
   isJoined: state.game.isJoined,
 });
 const mapDispatch = {
+  setUserID: (id: string) => setUserID(id),
   setGameID: (id: string) => setGameID(id),
   setIsCreated: (isCreated: boolean) => setIsCreated(isCreated),
   setIsJoined: (isJoined: boolean) => setIsJoined(isJoined),
+  setSocket: (socket: WebSocket) => setSocket(socket),
 };
 const connector = connect(mapState, mapDispatch);
 type PropsFromRedux = ConnectedProps<typeof connector>;
@@ -33,19 +38,34 @@ type Props = PropsFromRedux & RouteComponentProps<any>;
 
 const GameScreen: React.FC<Props> = (props: Props) => {
   const [isLoading, setIsLoading] = useState(true);
+  const [temporary, setTemporary] = useState('placeholder');
 
   useEffect(() => {
     const gameIDFromURL: string = props.match.params.gameID;
     props.setGameID(gameIDFromURL);
 
-    // TODO: logic which establishes a Websocket connection with the server goes
-    // here.
-    //
+    // Establish a Websocket connection with the server.
+    const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
+    const socketURL = `${protocol}${SERVER_URL}/ws?gameID=${gameIDFromURL}`;
+    const socket = new WebSocket(socketURL);
+    socket.onopen = () => setSocket(socket);
+
+    // Temporary!
+    // TODO: remove this! Just testing to see if I can send messages between a
+    // client and the server through a Websocket.
+    socket.onmessage = (event) => setTemporary(JSON.parse(event.data).id);
+
     // For now, just stub this out & pretend that the server told us that a game
     // with the provided ID doesn't exist, therefore we'll be creating a new
     // one.
     props.setIsCreated(false);
     props.setIsJoined(false);
+
+    // Once a connection is established, the server will create a new game with
+    // the provided gameID if one doens't already exist. Once a game has either
+    // been found or a new one has been created, the server will then add a new
+    // Player to that game. That Player will have its own unique ID, which the
+    // client needs to store. Listen for that new Player ID here, as well.
 
     setIsLoading(false);
   }, []);
@@ -61,7 +81,7 @@ const GameScreen: React.FC<Props> = (props: Props) => {
   if (props.isCreated) {
     return <JoinGameScreen />;
   }
-  return <CreateGameScreen />;
+  return <CreateGameScreen temp={temporary} />;
 };
 
 export default connector(GameScreen);

--- a/client/src/store/constants.ts
+++ b/client/src/store/constants.ts
@@ -1,0 +1,3 @@
+// TODO: set this dynamically depending on if we're in dev or prod.
+// eslint-disable-next-line import/prefer-default-export
+export const SERVER_URL = 'localhost:6969';

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -2,11 +2,13 @@ import { combineReducers, createStore } from 'redux';
 import gameReducer from './game/reducers';
 import userReducer from './user/reducers';
 import boardReducer from './board/reducers';
+import lobbyReducer from './lobby/reducers';
 
 const rootReducer = combineReducers({
   game: gameReducer,
   user: userReducer,
   board: boardReducer,
+  lobby: lobbyReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/client/src/store/lobby/actions.ts
+++ b/client/src/store/lobby/actions.ts
@@ -1,0 +1,40 @@
+import {
+  LobbyActionTypes,
+  ADD_RED_TEAM_PLAYER,
+  Player,
+  ADD_BLUE_TEAM_PLAYER,
+  REMOVE_RED_TEAM_PLAYER,
+  REMOVE_BLUE_TEAM_PLAYER,
+} from './types';
+
+// Action creator for the ADD_RED_TEAM_PLAYER action type.
+export function addRedTeamPlayer(player: Player): LobbyActionTypes {
+  return {
+    type: ADD_RED_TEAM_PLAYER,
+    payload: player,
+  };
+}
+
+// Action creator for the ADD_BLUE_TEAM_PLAYER action type.
+export function addBlueTeamPlayer(player: Player): LobbyActionTypes {
+  return {
+    type: ADD_BLUE_TEAM_PLAYER,
+    payload: player,
+  };
+}
+
+// Action creator for the REMOVE_RED_TEAM_PLAYER action type.
+export function removeRedTeamPlayer(displayName: string): LobbyActionTypes {
+  return {
+    type: REMOVE_RED_TEAM_PLAYER,
+    payload: displayName,
+  };
+}
+
+// Action creator for the REMOVE_BLUE_TEAM_PLAYER action type.
+export function removeBlueTeamPlayer(displayName: string): LobbyActionTypes {
+  return {
+    type: REMOVE_BLUE_TEAM_PLAYER,
+    payload: displayName,
+  };
+}

--- a/client/src/store/lobby/reducers.ts
+++ b/client/src/store/lobby/reducers.ts
@@ -1,0 +1,47 @@
+import {
+  LobbyState,
+  LobbyActionTypes,
+  ADD_RED_TEAM_PLAYER,
+  ADD_BLUE_TEAM_PLAYER,
+  REMOVE_RED_TEAM_PLAYER,
+  REMOVE_BLUE_TEAM_PLAYER,
+} from './types';
+
+const initialState: LobbyState = {
+  redTeam: [],
+  blueTeam: [],
+};
+
+export default function lobbyReducer(
+  state = initialState,
+  action: LobbyActionTypes,
+): LobbyState {
+  switch (action.type) {
+    case ADD_RED_TEAM_PLAYER:
+      return {
+        ...state,
+        redTeam: [...state.redTeam, action.payload],
+      };
+    case ADD_BLUE_TEAM_PLAYER:
+      return {
+        ...state,
+        blueTeam: [...state.blueTeam, action.payload],
+      };
+    case REMOVE_RED_TEAM_PLAYER:
+      return {
+        ...state,
+        redTeam: state.redTeam.filter(
+          (player) => player.displayName !== action.payload,
+        ),
+      };
+    case REMOVE_BLUE_TEAM_PLAYER:
+      return {
+        ...state,
+        blueTeam: state.blueTeam.filter(
+          (player) => player.displayName !== action.payload,
+        ),
+      };
+    default:
+      return state;
+  }
+}

--- a/client/src/store/lobby/types.ts
+++ b/client/src/store/lobby/types.ts
@@ -1,0 +1,37 @@
+// Players are different from Users (UserState in users/types.ts): the User is
+// the current client, while Players are all other clients that are
+// participating in the same game, or are in the same game lobby.
+export interface Player {
+  displayName: string;
+}
+
+export interface LobbyState {
+  redTeam: Player[];
+  blueTeam: Player[];
+}
+
+export const ADD_RED_TEAM_PLAYER = 'ADD_RED_TEAM_PLAYER';
+interface AddRedTeamPlayerAction {
+  type: typeof ADD_RED_TEAM_PLAYER;
+  payload: Player;
+}
+export const ADD_BLUE_TEAM_PLAYER = 'ADD_BLUE_TEAM_PLAYER';
+interface AddBlueTeamPlayerAction {
+  type: typeof ADD_BLUE_TEAM_PLAYER;
+  payload: Player;
+}
+export const REMOVE_RED_TEAM_PLAYER = 'REMOVE_RED_TEAM_PLAYER';
+interface RemoveRedTeamPlayerAction {
+  type: typeof REMOVE_RED_TEAM_PLAYER;
+  payload: string;
+}
+export const REMOVE_BLUE_TEAM_PLAYER = 'REMOVE_BLUE_TEAM_PLAYER';
+interface RemoveBlueTeamPlayerAction {
+  type: typeof REMOVE_BLUE_TEAM_PLAYER;
+  payload: string;
+}
+export type LobbyActionTypes =
+  | AddRedTeamPlayerAction
+  | AddBlueTeamPlayerAction
+  | RemoveRedTeamPlayerAction
+  | RemoveBlueTeamPlayerAction;

--- a/client/src/store/user/actions.ts
+++ b/client/src/store/user/actions.ts
@@ -2,7 +2,16 @@ import {
   UserActionTypes,
   SET_DISPLAY_NAME,
   SET_IS_SETTING_DISPLAY_NAME,
+  SET_USER_ID,
 } from './types';
+
+// Action creator for the SET_USER_ID action type.
+export function setUserID(id: string): UserActionTypes {
+  return {
+    type: SET_USER_ID,
+    payload: id,
+  };
+}
 
 // Action creator for the SET_DISPLAY_NAME action type.
 export function setDisplayName(displayName: string): UserActionTypes {

--- a/client/src/store/user/reducers.ts
+++ b/client/src/store/user/reducers.ts
@@ -3,9 +3,11 @@ import {
   UserActionTypes,
   SET_DISPLAY_NAME,
   SET_IS_SETTING_DISPLAY_NAME,
+  SET_USER_ID,
 } from './types';
 
 const initialState: UserState = {
+  id: '',
   displayName: '',
   isSettingDisplayName: true,
 };
@@ -15,6 +17,11 @@ export default function userReducer(
   action: UserActionTypes,
 ): UserState {
   switch (action.type) {
+    case SET_USER_ID:
+      return {
+        ...state,
+        id: action.payload,
+      };
     case SET_DISPLAY_NAME:
       return {
         ...state,

--- a/client/src/store/user/types.ts
+++ b/client/src/store/user/types.ts
@@ -2,10 +2,16 @@
 // client, while Players are all other clients that are participating in the
 // same game, or are in the same game lobby.
 export interface UserState {
+  id: string;
   displayName: string;
   isSettingDisplayName: boolean;
 }
 
+export const SET_USER_ID = 'SET_USER_ID';
+interface SetIDAction {
+  type: typeof SET_USER_ID;
+  payload: string;
+}
 export const SET_DISPLAY_NAME = 'SET_DISPLAY_NAME';
 interface SetDisplayNameAction {
   type: typeof SET_DISPLAY_NAME;
@@ -17,5 +23,6 @@ interface SetIsSettingDisplayNameAction {
   payload: boolean;
 }
 export type UserActionTypes =
+  | SetIDAction
   | SetDisplayNameAction
   | SetIsSettingDisplayNameAction;

--- a/client/src/store/user/types.ts
+++ b/client/src/store/user/types.ts
@@ -1,3 +1,6 @@
+// Users are different from Players (in lobby/types.ts): the User is the current
+// client, while Players are all other clients that are participating in the
+// same game, or are in the same game lobby.
 export interface UserState {
   displayName: string;
   isSettingDisplayName: boolean;

--- a/client/src/store/websocket/actions.ts
+++ b/client/src/store/websocket/actions.ts
@@ -1,0 +1,9 @@
+import { WebsocketActionTypes, SET_SOCKET } from './types';
+
+// Action creator for the SET_SOCKET action type.
+export default function setSocket(socket: WebSocket): WebsocketActionTypes {
+  return {
+    type: SET_SOCKET,
+    payload: socket,
+  };
+}

--- a/client/src/store/websocket/reducers.ts
+++ b/client/src/store/websocket/reducers.ts
@@ -1,0 +1,20 @@
+import { WebsocketActionTypes, WebsocketState, SET_SOCKET } from './types';
+
+const initialState: WebsocketState = {
+  socket: undefined,
+};
+
+export default function websocketReducer(
+  state = initialState,
+  action: WebsocketActionTypes,
+): WebsocketState {
+  switch (action.type) {
+    case SET_SOCKET:
+      return {
+        ...state,
+        socket: action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/client/src/store/websocket/types.ts
+++ b/client/src/store/websocket/types.ts
@@ -1,0 +1,10 @@
+export interface WebsocketState {
+  socket?: WebSocket;
+}
+
+export const SET_SOCKET = 'SET_SOCKET';
+interface SetSocketAction {
+  type: typeof SET_SOCKET;
+  payload: WebSocket;
+}
+export type WebsocketActionTypes = SetSocketAction;

--- a/server/go.mod
+++ b/server/go.mod
@@ -3,6 +3,7 @@ module github.com/nchaloult/codenames
 go 1.14
 
 require (
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.2
 )

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,3 +1,5 @@
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/server/model/player.go
+++ b/server/model/player.go
@@ -1,19 +1,35 @@
 package model
 
-import "github.com/gorilla/websocket"
+import (
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
 
 // Player stores information about a player in a Game, as well as the Websocket
 // connection that they're connected to the server with. Players are managed by
 // an Interactor.
 type Player struct {
 	Conn        *websocket.Conn
+	ID          string
 	DisplayName string
 	IsOnRedTeam bool
 	IsSpymaster bool
 }
 
-// NewPlayer returns a pointer to a new Player object with initialized fields.
-// Sets IsOnRedTeam to true and IsSpymaster to false by default.
-func NewPlayer(conn *websocket.Conn, displayName string) *Player {
-	return &Player{conn, displayName, true, false}
+// NewPlayer returns a pointer to a new Player object with the provided
+// connection pointer. Generates a new unique Player ID and sends it to the
+// client listening on the other end of the Websocket connection. Sets
+// IsOnRedTeam to true and IsSpymaster to false by default.
+func NewPlayer(conn *websocket.Conn) *Player {
+	id := uuid.New()
+	playerIDMsg := map[string]interface{}{
+		"id": id,
+	}
+	conn.WriteJSON(playerIDMsg)
+	return &Player{
+		Conn:        conn,
+		ID:          id.String(),
+		IsOnRedTeam: true,
+		IsSpymaster: false,
+	}
 }

--- a/server/model/player.go
+++ b/server/model/player.go
@@ -26,6 +26,7 @@ func NewPlayer(conn *websocket.Conn) *Player {
 		"id": id,
 	}
 	conn.WriteJSON(playerIDMsg)
+
 	return &Player{
 		Conn:        conn,
 		ID:          id.String(),

--- a/server/server.go
+++ b/server/server.go
@@ -110,7 +110,7 @@ type wsRequestBody struct {
 // wsHandler serves requests at the /ws route. Creates a new game (or adds a new
 // player to the existing game that corresponds with the provided gameID), and
 // attempts to establish a Websocket connection with a client. Expects "gameID"
-// and "displayName" as query parameters when the /ws endpoint is hit.
+// as a query parameter when the /ws endpoint is hit.
 func (s *Server) wsHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract info from query params.
 	queryParams := r.URL.Query()
@@ -120,12 +120,6 @@ func (s *Server) wsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	gameID := queryParams["gameID"][0]
-	if _, ok := queryParams["displayName"]; !ok {
-		errMsg := fmt.Sprint("the \"displayName\" query param is required")
-		http.Error(w, errMsg, http.StatusBadRequest)
-		return
-	}
-	displayName := queryParams["displayName"][0]
 
 	// Look for an active game associated with the provided gameID. If one
 	// doesn't exist, then create a new one.
@@ -149,6 +143,9 @@ func (s *Server) wsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a new player for our connected client.
-	newPlayer := model.NewPlayer(conn, displayName)
+	// TODO: make this async by pushing this newPlayer pointer to some channel.
+	// This will break if more than one client hits the /ws endpoint at once
+	// with the same gameID.
+	newPlayer := model.NewPlayer(conn)
 	s.activeGames[gameID].Players[newPlayer.DisplayName] = newPlayer
 }


### PR DESCRIPTION
Related to #7 

This PR is a "first draft" implementation of establishing and maintaining a persistent Websocket connection between each client and a server. When a client visits a `/:gameID` URL, the `GameScreen` component hits the `/ws?gameID=:gameID` endpoint. The server creates a new `Game` with that ID if one doesn't exist, and adds a new `Player` to that `Game`. When that new `Player` is created, a unique player ID is generated for it. This is communicated to the client via that fresh Websocket connection.

As of now, whether or not a new `Game` is created or one already existed isn't communicated to the client. There's also no standardized format or structure to messages sent along that Websocket connection. These things will be sorted out in the future.