### PR TITLE
Add constructAndSendResponse() func

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -52,4 +53,17 @@ func (a *API) ListenOnEndpoints(handlers []RouteHandler) {
 	log.Printf("Listening on port %d....\n", a.port)
 	portAddr := fmt.Sprintf(":%d", a.port)
 	log.Fatal(http.ListenAndServe(portAddr, a.router))
+}
+
+// constructAndSendResponse adds important, common headers to endpoint
+// responses, and marshals the provided response body into JSON.
+func constructAndSendResponse(w http.ResponseWriter, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+
+	err := json.NewEncoder(w).Encode(body)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to encode response as JSON: %v", err)
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
 }

--- a/server/api/health.go
+++ b/server/api/health.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -30,15 +28,7 @@ func (h *HealthHandler) healthHandler(w http.ResponseWriter, r *http.Request) {
 		"ok":             true,
 		"numActiveGames": len(h.manager.ActiveGames),
 	}
-
-	w.Header().Set("Content-Type", "application/json")
-	err := json.NewEncoder(w).Encode(response)
-	if err != nil {
-		errCode := http.StatusInternalServerError
-		errMsg := fmt.Sprintf("Failed to encode response as JSON: %v\n", err)
-		http.Error(w, errMsg, errCode)
-		return
-	}
+	constructAndSendResponse(w, response)
 }
 
 // RegisterRoutes registers handlers for all of the routes that wsHandler

--- a/server/api/ws.go
+++ b/server/api/ws.go
@@ -55,7 +55,7 @@ func (h *WSHandler) defaultHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract info from query params.
 	queryParams := r.URL.Query()
 	if _, ok := queryParams["gameID"]; !ok {
-		errMsg := fmt.Sprint("the \"gameID\" query param is required")
+		errMsg := "the \"gameID\" query param is required"
 		http.Error(w, errMsg, http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
This PR proposes to introduce a `constructAndSendResponse()` utility func. It's a good home for repetitive steps that are involved with responding to an HTTP request, like setting response headers and marshaling a response body to JSON. It's also a good place for logging information about whether the response was constructed and sent successfully or not to be added in the future.