### PR TITLE
Add basic infrastructure to listen for events

### DIFF
--- a/client/src/screens/GameScreen.tsx
+++ b/client/src/screens/GameScreen.tsx
@@ -47,7 +47,7 @@ const GameScreen: React.FC<Props> = (props: Props) => {
     const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
     const socketURL = `${protocol}${SERVER_URL}/ws?gameID=${gameIDFromURL}`;
     const socket = new WebSocket(socketURL);
-    socket.onopen = () => setSocket(socket);
+    socket.onopen = () => props.setSocket(socket);
 
     // For now, just stub this out & pretend that the server told us that a game
     // with the provided ID doesn't exist, therefore we'll be creating a new

--- a/client/src/screens/SetDisplayNameScreen.tsx
+++ b/client/src/screens/SetDisplayNameScreen.tsx
@@ -33,10 +33,27 @@ const SetDisplayNameScreen: React.FC<PropsFromRedux> = (
       kind: 'changeDisplayName',
       body: newDisplayName,
     };
-    props.socket?.send(JSON.stringify(changeDisplayNameEvent));
+    if (props.socket) {
+      props.socket.send(JSON.stringify(changeDisplayNameEvent));
+      // Listen for an acknowledgement from the server.
+      props.socket.onmessage = (f) => {
+        const eventResponse = JSON.parse(f.data);
+        if (!eventResponse.ok) {
+          // TODO: better error handling
+          alert('Attempt to change display name failed on the server side.');
+          return;
+        }
 
-    props.setDisplayName(newDisplayName);
-    props.setIsSettingDisplayName(false);
+        props.setDisplayName(newDisplayName);
+        props.setIsSettingDisplayName(false);
+      };
+    } else {
+      // TODO: better error handling
+      alert(
+        'Websocket var is undefined in Redux global store.' +
+          ' Cannot communicate with the server',
+      );
+    }
   };
 
   return (

--- a/client/src/screens/SetDisplayNameScreen.tsx
+++ b/client/src/screens/SetDisplayNameScreen.tsx
@@ -8,6 +8,7 @@ import { setDisplayName, setIsSettingDisplayName } from '../store/user/actions';
 const mapState = (state: RootState) => ({
   displayName: state.user.displayName,
   isSettingDisplayName: state.user.isSettingDisplayName,
+  socket: state.websocket.socket,
 });
 const mapDispatch = {
   setDisplayName: (displayName: string) => setDisplayName(displayName),
@@ -26,6 +27,14 @@ const SetDisplayNameScreen: React.FC<PropsFromRedux> = (
 
   const handleDisplayNameFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    // Send a "change display name" event to the server.
+    const changeDisplayNameEvent = {
+      kind: 'changeDisplayName',
+      body: newDisplayName,
+    };
+    props.socket?.send(JSON.stringify(changeDisplayNameEvent));
+
     props.setDisplayName(newDisplayName);
     props.setIsSettingDisplayName(false);
   };

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -3,12 +3,14 @@ import gameReducer from './game/reducers';
 import userReducer from './user/reducers';
 import boardReducer from './board/reducers';
 import lobbyReducer from './lobby/reducers';
+import websocketReducer from './websocket/reducers';
 
 const rootReducer = combineReducers({
   game: gameReducer,
   user: userReducer,
   board: boardReducer,
   lobby: lobbyReducer,
+  websocket: websocketReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/server/api/ws.go
+++ b/server/api/ws.go
@@ -91,7 +91,7 @@ func (h *WSHandler) defaultHandler(w http.ResponseWriter, r *http.Request) {
 	// TODO: make this async by pushing this newPlayer pointer to some channel.
 	// This will break if more than one client hits the /ws endpoint at once
 	// with the same gameID.
-	newPlayer := model.NewPlayer(conn)
+	newPlayer := realtime.NewPlayer(conn)
 	h.manager.ActiveGames[gameID].Players[newPlayer.DisplayName] = newPlayer
 }
 

--- a/server/api/ws.go
+++ b/server/api/ws.go
@@ -93,6 +93,8 @@ func (h *WSHandler) defaultHandler(w http.ResponseWriter, r *http.Request) {
 	// with the same gameID.
 	newPlayer := realtime.NewPlayer(conn)
 	h.manager.ActiveGames[gameID].Players[newPlayer.DisplayName] = newPlayer
+
+	go newPlayer.ListenForEvents()
 }
 
 // RegisterRoutes registers handlers for all of the routes that wsHandler

--- a/server/realtime/interactor.go
+++ b/server/realtime/interactor.go
@@ -17,7 +17,7 @@ type Interactor struct {
 
 	// Players stores Player objects for each active client, indexed by their
 	// display name.
-	Players map[string]*model.Player
+	Players map[string]*Player
 }
 
 // NewInteractor returns a pointer to a new Interactor object initialized with
@@ -25,6 +25,6 @@ type Interactor struct {
 func NewInteractor(game *model.Game) *Interactor {
 	return &Interactor{
 		Game:    game,
-		Players: make(map[string]*model.Player, 0),
+		Players: make(map[string]*Player, 0),
 	}
 }

--- a/server/realtime/player.go
+++ b/server/realtime/player.go
@@ -1,4 +1,4 @@
-package model
+package realtime
 
 import (
 	"github.com/google/uuid"

--- a/server/realtime/player.go
+++ b/server/realtime/player.go
@@ -62,6 +62,7 @@ func (p *Player) ListenForEvents() {
 		switch event.Kind {
 		case changeDisplayName:
 			p.DisplayName = event.Body.(string)
+			constructAndSendResponse(p.Conn, changeDisplayName, nil)
 		default:
 			errMsg := fmt.Errorf("unrecognized eventKind: %v", event.Kind)
 			constructAndSendErr(p.Conn, errMsg)

--- a/server/realtime/player.go
+++ b/server/realtime/player.go
@@ -59,11 +59,11 @@ func (p *Player) ListenForEvents() {
 		}
 
 		// Decide how to behave depending on the event's type/kind.
-		switch event.kind {
+		switch event.Kind {
 		case changeDisplayName:
 			log.Printf("event received from Player %s to change their display name\n", p.ID)
 		default:
-			errMsg := fmt.Errorf("unrecognized eventKind: %v", event.kind)
+			errMsg := fmt.Errorf("unrecognized eventKind: %v", event.Kind)
 			constructAndSendErr(p.Conn, errMsg)
 		}
 	}

--- a/server/realtime/player.go
+++ b/server/realtime/player.go
@@ -61,7 +61,7 @@ func (p *Player) ListenForEvents() {
 		// Decide how to behave depending on the event's type/kind.
 		switch event.Kind {
 		case changeDisplayName:
-			log.Printf("event received from Player %s to change their display name\n", p.ID)
+			p.DisplayName = event.Body.(string)
 		default:
 			errMsg := fmt.Errorf("unrecognized eventKind: %v", event.Kind)
 			constructAndSendErr(p.Conn, errMsg)

--- a/server/realtime/ws.go
+++ b/server/realtime/ws.go
@@ -11,16 +11,16 @@ const (
 // event mirrors the structure of JSON messages that clients send to the server
 // via a Websocket connection.
 type event struct {
-	kind eventKind
-	body interface{}
+	Kind eventKind   `json:"kind"`
+	Body interface{} `json:"body"`
 }
 
 // eventResponse mirrors the structure of JSON messages that the server sends in
 // response to a client's Websocket message.
 type eventResponse struct {
-	ok   bool
-	kind eventKind
-	body interface{}
+	Ok   bool        `json:"ok"`
+	Kind eventKind   `json:"kind"`
+	Body interface{} `json:"body"`
 }
 
 // constructAndSendResponse builds an eventResponse struct with the provided
@@ -31,13 +31,13 @@ func constructAndSendResponse(
 	kind eventKind,
 	body interface{},
 ) {
-	response := eventResponse{ok: true, kind: kind, body: body}
+	response := eventResponse{Ok: true, Kind: kind, Body: body}
 	conn.WriteJSON(response)
 }
 
 // constructAndSendErr builds an eventResponse struct with the provided error,
 // marshals it to JSON, and sends it along the provided Websocket connection.
 func constructAndSendErr(conn *websocket.Conn, err error) {
-	response := eventResponse{ok: false, body: err}
+	response := eventResponse{Ok: false, Body: err}
 	conn.WriteJSON(response)
 }

--- a/server/realtime/ws.go
+++ b/server/realtime/ws.go
@@ -25,13 +25,16 @@ type eventResponse struct {
 
 // constructAndSendResponse builds an eventResponse struct with the provided
 // fields, marshals it to JSON, and sends it along the provided Websocket
-// connection.
+// connection. Body parameter may be nil.
 func constructAndSendResponse(
 	conn *websocket.Conn,
 	kind eventKind,
 	body interface{},
 ) {
-	response := eventResponse{Ok: true, Kind: kind, Body: body}
+	response := eventResponse{Ok: true, Kind: kind}
+	if body != nil {
+		response.Body = body
+	}
 	conn.WriteJSON(response)
 }
 

--- a/server/realtime/ws.go
+++ b/server/realtime/ws.go
@@ -1,0 +1,43 @@
+package realtime
+
+import "github.com/gorilla/websocket"
+
+type eventKind string
+
+const (
+	changeDisplayName eventKind = "changeDisplayName"
+)
+
+// event mirrors the structure of JSON messages that clients send to the server
+// via a Websocket connection.
+type event struct {
+	kind eventKind
+	body interface{}
+}
+
+// eventResponse mirrors the structure of JSON messages that the server sends in
+// response to a client's Websocket message.
+type eventResponse struct {
+	ok   bool
+	kind eventKind
+	body interface{}
+}
+
+// constructAndSendResponse builds an eventResponse struct with the provided
+// fields, marshals it to JSON, and sends it along the provided Websocket
+// connection.
+func constructAndSendResponse(
+	conn *websocket.Conn,
+	kind eventKind,
+	body interface{},
+) {
+	response := eventResponse{ok: true, kind: kind, body: body}
+	conn.WriteJSON(response)
+}
+
+// constructAndSendErr builds an eventResponse struct with the provided error,
+// marshals it to JSON, and sends it along the provided Websocket connection.
+func constructAndSendErr(conn *websocket.Conn, err error) {
+	response := eventResponse{ok: false, body: err}
+	conn.WriteJSON(response)
+}


### PR DESCRIPTION
This PR proposes to lay down the foundation for listening for events and event responses between clients and a server. Some things are temporary (especially how events are sent and responses are received on the client). This is more of a demonstration of functionality rather than a final implementation of how events will be sent and received in the future.

For now, only one event is supported: `changeDisplayName`. When more events are introduced, `Player` objects on the server may need to store a pointer to the `Interactor` that they're associated with.