### PR TITLE
Standardize WS event handling on the client

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -26,6 +26,7 @@
   },
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
+    "@typescript-eslint/no-explicit-any": "off",
     "react/jsx-filename-extension": [
       2,
       {

--- a/client/src/realtime/ws.ts
+++ b/client/src/realtime/ws.ts
@@ -2,7 +2,7 @@ import { SERVER_URL } from '../constants';
 
 // establishWSConnection attempts to establish a persistent Websocket connection
 // with the server.
-export default function establishWSConnection(gameID: string): WebSocket {
+export function establishWSConnection(gameID: string): WebSocket {
   const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
   const socketURL = `${protocol}${SERVER_URL}/ws?gameID=${gameID}`;
   const socket = new WebSocket(socketURL);
@@ -14,4 +14,87 @@ export default function establishWSConnection(gameID: string): WebSocket {
   };
 
   return socket;
+}
+
+export enum EventKind {
+  ChangeDisplayName = 'ChangeDisplayName',
+}
+
+// Event mirrors the structure of JSON messages that the server sends to clients
+// via Websocket connections when something occurrs that all clients in a game
+// need to be aware of.
+interface Event {
+  kind: EventKind;
+  body: any;
+}
+
+// EventResponse mirrors the structure of JSON messages that the server sends to
+// a client via a Websocket connection in response to an event that that client
+// sent to the server.
+interface EventResponse {
+  ok: boolean;
+  kind: EventKind;
+  body?: any;
+}
+
+// constructAndSendEvent builds an Event with the provided fields, serializes it
+// into a string, and sends it along the provided Websocket connection.
+export function constructAndSendEvent(
+  socket: WebSocket,
+  kind: EventKind,
+  body: any,
+): void {
+  const event: Event = { kind, body };
+  socket.send(JSON.stringify(event));
+}
+
+// constructAndSendResponse builds an EventResponse with the provided fields,
+// serializes it into a string, and sends it along the provided Websocket
+// connection. Body parameter may be omitted.
+export function constructAndSendResponse(
+  socket: WebSocket,
+  kind: EventKind,
+  body?: any,
+): void {
+  const response: EventResponse = { ok: true, kind };
+  if (body) {
+    response.body = body;
+  }
+  socket.send(JSON.stringify(response));
+}
+
+// constructAndSendErr builds an EventResponse with the provided fields,
+// serializes it into a string, and sends it along the provided Websocket
+// connection. Body parameter may be omitted.
+export function constructAndSendErr(
+  socket: WebSocket,
+  kind: EventKind,
+  body?: any,
+): void {
+  const response: EventResponse = { ok: false, kind };
+  if (body) {
+    response.body = body;
+  }
+  socket.send(JSON.stringify(response));
+}
+
+// isResponseOK returns whether an event response object is carrying information
+// about an something that went wrong. It's also the future home of logging or
+// some kind of universal error handling logic for error responses that indicate
+// there's a problem somewhere.
+export function isResponseOK(response: any): boolean {
+  if (!('ok' in response)) {
+    return false;
+  }
+  return response.ok;
+}
+
+// getResponseErr returns the body of an EventResponse that indicated something
+// went wrong somewhere. If the provided EventResponse doesn't indicate that
+// something went wrong, then null is returned.
+export function getResponseErr(response: EventResponse): any {
+  if (response.ok) {
+    return null;
+  }
+  return response.body;
 }

--- a/client/src/realtime/ws.ts
+++ b/client/src/realtime/ws.ts
@@ -17,7 +17,7 @@ export function establishWSConnection(gameID: string): WebSocket {
 }
 
 export enum EventKind {
-  ChangeDisplayName = 'ChangeDisplayName',
+  changeDisplayName = 'CHANGE_DISPLAY_NAME',
 }
 
 // Event mirrors the structure of JSON messages that the server sends to clients

--- a/client/src/realtime/ws.ts
+++ b/client/src/realtime/ws.ts
@@ -1,0 +1,17 @@
+import { SERVER_URL } from '../constants';
+
+// establishWSConnection attempts to establish a persistent Websocket connection
+// with the server.
+export default function establishWSConnection(gameID: string): WebSocket {
+  const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
+  const socketURL = `${protocol}${SERVER_URL}/ws?gameID=${gameID}`;
+  const socket = new WebSocket(socketURL);
+
+  // TODO: better error handling.
+  socket.onerror = () => {
+    alert('Something went wrong with the Websocket connection to the server');
+    socket.close(1006);
+  };
+
+  return socket;
+}

--- a/client/src/screens/GameScreen.tsx
+++ b/client/src/screens/GameScreen.tsx
@@ -9,7 +9,7 @@ import BoardScreen from './BoardScreen';
 import JoinGameScreen from './JoinGameScreen';
 import { setUserID } from '../store/user/actions';
 import setSocket from '../store/websocket/actions';
-import { SERVER_URL } from '../constants';
+import establishWSConnection from '../realtime/ws';
 
 // In this component, a Websocket connection is established with the server.
 // Depending on whether the game with the provided gameID has already been
@@ -44,10 +44,8 @@ const GameScreen: React.FC<Props> = (props: Props) => {
     props.setGameID(gameIDFromURL);
 
     // Establish a Websocket connection with the server.
-    const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
-    const socketURL = `${protocol}${SERVER_URL}/ws?gameID=${gameIDFromURL}`;
-    const socket = new WebSocket(socketURL);
-    socket.onopen = () => props.setSocket(socket);
+    const socket = establishWSConnection(gameIDFromURL);
+    props.setSocket(socket);
 
     // For now, just stub this out & pretend that the server told us that a game
     // with the provided ID doesn't exist, therefore we'll be creating a new

--- a/client/src/screens/GameScreen.tsx
+++ b/client/src/screens/GameScreen.tsx
@@ -9,7 +9,7 @@ import BoardScreen from './BoardScreen';
 import JoinGameScreen from './JoinGameScreen';
 import { setUserID } from '../store/user/actions';
 import setSocket from '../store/websocket/actions';
-import establishWSConnection from '../realtime/ws';
+import { establishWSConnection } from '../realtime/ws';
 
 // In this component, a Websocket connection is established with the server.
 // Depending on whether the game with the provided gameID has already been

--- a/client/src/screens/SetDisplayNameScreen.tsx
+++ b/client/src/screens/SetDisplayNameScreen.tsx
@@ -42,7 +42,7 @@ const SetDisplayNameScreen: React.FC<PropsFromRedux> = (
     // Send a "change display name" event to the server.
     constructAndSendEvent(
       props.socket,
-      EventKind.ChangeDisplayName,
+      EventKind.changeDisplayName,
       newDisplayName,
     );
     // Listen for an acknowledgement from the server.

--- a/server/realtime/ws.go
+++ b/server/realtime/ws.go
@@ -5,7 +5,7 @@ import "github.com/gorilla/websocket"
 type eventKind string
 
 const (
-	changeDisplayName eventKind = "changeDisplayName"
+	changeDisplayName eventKind = "CHANGE_DISPLAY_NAME"
 )
 
 // event mirrors the structure of JSON messages that clients send to the server


### PR DESCRIPTION
Sorta kinda almost related to #7 

This PR introduces a few utility funcs and types that help standardize the way that events are received, parsed, and sent on the client. This mirrors much of the work that was done on the server for this purpose.

Some notable new items:

- `Event` and `EventResponse` types
- `EventKind` enum
    - Mirrors the custom `type eventKind string` that exists on the server
    - EventKind values must be hard-coded, and kept in sync with the `eventKind` values on the server
        - This isn't ideal, but I'm not sure how to have both the client and the server pull these constant values from one place
        - Putting all of the event kinds in environment variables seems silly