### PR TITLE
Make global Redux store accessible outside of React components

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -4,11 +4,9 @@ import './index.css';
 
 import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { configureStore } from './store';
+import { store } from './store';
 import LandingScreen from './screens/LandingScreen';
 import GameScreen from './screens/GameScreen';
-
-const store = configureStore();
 
 const App: React.FC = () => (
   <React.StrictMode>

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -15,6 +15,11 @@ const rootReducer = combineReducers({
 
 export type RootState = ReturnType<typeof rootReducer>;
 
-export function configureStore() {
-  return createStore(rootReducer);
+// configureStore creates and returns a Redux global store object. It's also the
+// future home for adding middleware or some kind of logging.
+// TODO: figure out how to type the reducer param properly.
+function configureStore(reducer: any) {
+  return createStore(reducer);
 }
+
+export const store = configureStore(rootReducer);


### PR DESCRIPTION
Depending on the client's state, it only cares to listen for particular Websocket messages from the server. For example, if a client is in a lobby for an ongoing game, then they aren't concerned with listening for Websocket messages that are carrying a game state update. instead, the client should start listening for messages like that once it picks a team and officially joins the game.

Most of the Websocket logic has been migrated outside of React components. This makes the codebase more organized and maintainable, but it also means that the logic doesn't have access to the Redux global store anymore. This PR proposes to export the Redux global store so that it may be accessed in any file.

I'm not sure if doing something like this is good practice. For the sake of this hobbyist project, I think it's fine, but I'll probably revisit this in the future to see if there's a better way to access a Redux store outside of React components.