### PR TITLE
Add new infra to listen for WS events

### DIFF
--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,4 +1,4 @@
-import { combineReducers, createStore } from 'redux';
+import { combineReducers, createStore, Action, Store } from 'redux';
 import gameReducer from './game/reducers';
 import userReducer from './user/reducers';
 import boardReducer from './board/reducers';
@@ -18,7 +18,7 @@ export type RootState = ReturnType<typeof rootReducer>;
 // configureStore creates and returns a Redux global store object. It's also the
 // future home for adding middleware or some kind of logging.
 // TODO: figure out how to type the reducer param properly.
-function configureStore(reducer: any) {
+function configureStore(reducer: any): Store<RootState, Action<any>> {
   return createStore(reducer);
 }
 

--- a/server/realtime/player.go
+++ b/server/realtime/player.go
@@ -61,9 +61,9 @@ func (p *Player) ListenForEvents() {
 
 		// Decide how to behave depending on the event's type/kind.
 		switch event.Kind {
-		case changeDisplayName:
+		case ChangeDisplayName:
 			p.DisplayName = event.Body.(string)
-			constructAndSendResponse(p.Conn, changeDisplayName, nil)
+			constructAndSendResponse(p.Conn, ChangeDisplayName, nil)
 		default:
 			errMsg := fmt.Errorf("unrecognized eventKind: %v", event.Kind)
 			constructAndSendErr(p.Conn, errMsg)

--- a/server/realtime/player.go
+++ b/server/realtime/player.go
@@ -20,16 +20,10 @@ type Player struct {
 }
 
 // NewPlayer returns a pointer to a new Player object with the provided
-// connection pointer. Generates a new unique Player ID and sends it to the
-// client listening on the other end of the Websocket connection. Sets
-// IsOnRedTeam to true and IsSpymaster to false by default.
+// connection pointer. Sets IsOnRedTeam to true and IsSpymaster to false by
+// default.
 func NewPlayer(conn *websocket.Conn) *Player {
 	id := uuid.New()
-	playerIDMsg := map[string]interface{}{
-		"id": id,
-	}
-	conn.WriteJSON(playerIDMsg)
-
 	return &Player{
 		Conn:        conn,
 		ID:          id.String(),

--- a/server/realtime/player.go
+++ b/server/realtime/player.go
@@ -57,7 +57,6 @@ func (p *Player) ListenForEvents() {
 		switch event.Kind {
 		case ChangeDisplayName:
 			p.DisplayName = event.Body.(string)
-			constructAndSendResponse(p.Conn, ChangeDisplayName, nil)
 		default:
 			errMsg := fmt.Errorf("unrecognized eventKind: %v", event.Kind)
 			constructAndSendErr(p.Conn, errMsg)

--- a/server/realtime/ws.go
+++ b/server/realtime/ws.go
@@ -2,16 +2,24 @@ package realtime
 
 import "github.com/gorilla/websocket"
 
-type eventKind string
+// EventKind represents the type of an event or eventResponse that's sent over a
+// Websocket connection.
+type EventKind string
 
 const (
-	changeDisplayName eventKind = "CHANGE_DISPLAY_NAME"
+	// LobbyInfo describes an event that the server sends when a client first
+	// connects to a /:gameID URL. It communicates whether a game with the
+	// provided ID already exists or not.
+	LobbyInfo EventKind = "LOBBY_INFO"
+	// ChangeDisplayName describes an event that the client sends when they
+	// change their display name.
+	ChangeDisplayName EventKind = "CHANGE_DISPLAY_NAME"
 )
 
 // event mirrors the structure of JSON messages that clients send to the server
 // via a Websocket connection.
 type event struct {
-	Kind eventKind   `json:"kind"`
+	Kind EventKind   `json:"kind"`
 	Body interface{} `json:"body"`
 }
 
@@ -19,8 +27,15 @@ type event struct {
 // response to a client's Websocket message.
 type eventResponse struct {
 	Ok   bool        `json:"ok"`
-	Kind eventKind   `json:"kind"`
+	Kind EventKind   `json:"kind"`
 	Body interface{} `json:"body"`
+}
+
+// ConstructAndSendEvent builds an event struct with the provided fields,
+// marshals it to JSON, and sends it along the provided Websocket connection.
+func ConstructAndSendEvent(conn *websocket.Conn, kind EventKind, body interface{}) {
+	event := event{Kind: kind, Body: body}
+	conn.WriteJSON(event)
 }
 
 // constructAndSendResponse builds an eventResponse struct with the provided
@@ -28,7 +43,7 @@ type eventResponse struct {
 // connection. Body parameter may be nil.
 func constructAndSendResponse(
 	conn *websocket.Conn,
-	kind eventKind,
+	kind EventKind,
 	body interface{},
 ) {
 	response := eventResponse{Ok: true, Kind: kind}


### PR DESCRIPTION
This PR proposes to introduce new infrastructure for receiving WS events. The `establishWSConnection()` func is shuffled a bit, and a new `handleMsgFromServer()` func is introduced. This new infra is demonstrated by wiring up the `lobbyInfo` event, which lets the client know whether the game that they're trying to join is either new or already ongoing.