### PR TITLE
Create newPlayerID event

### DIFF
--- a/client/src/realtime/ws.ts
+++ b/client/src/realtime/ws.ts
@@ -1,9 +1,11 @@
 import { store, RootState } from '../store/index';
 import { SERVER_URL } from '../constants';
 import { setIsCreated, setIsJoined } from '../store/game/actions';
+import { setUserID } from '../store/user/actions';
 
 export enum EventKind {
   lobbyInfo = 'LOBBY_INFO',
+  newPlayerID = 'NEW_PLAYER_ID',
   changeDisplayName = 'CHANGE_DISPLAY_NAME',
   notAnEvent = 'NOT_AN_EVENT',
 }
@@ -126,6 +128,12 @@ function handleMsgFromServer(msg: MessageEvent) {
     }
   } else {
     switch (event.kind) {
+      case EventKind.newPlayerID:
+        // When a client first connects to a game, the server creates a new
+        // Player object for them with a UUID. The client needs to include this
+        // UUID in the body of select events that it sends.
+        store.dispatch(setUserID(event.body.id));
+        break;
       case EventKind.lobbyInfo:
         // When a client first visits a /:gameID URL and a Websocket connection
         // with the server is established, the server will send down a lobbyInfo

--- a/server/realtime/player.go
+++ b/server/realtime/player.go
@@ -22,11 +22,16 @@ type Player struct {
 // NewPlayer returns a pointer to a new Player object with the provided
 // connection pointer. Sets IsOnRedTeam to true and IsSpymaster to false by
 // default.
+//
+// NewPlayer sends a NewPlayerID event to the client once a UUID has been
+// generated for them.
 func NewPlayer(conn *websocket.Conn) *Player {
-	id := uuid.New()
+	id := uuid.New().String()
+	eventBody := map[string]string{"id": id}
+	ConstructAndSendEvent(conn, NewPlayerID, eventBody)
 	return &Player{
 		Conn:        conn,
-		ID:          id.String(),
+		ID:          id,
 		IsOnRedTeam: true,
 		IsSpymaster: false,
 	}

--- a/server/realtime/ws.go
+++ b/server/realtime/ws.go
@@ -11,6 +11,10 @@ const (
 	// connects to a /:gameID URL. It communicates whether a game with the
 	// provided ID already exists or not.
 	LobbyInfo EventKind = "LOBBY_INFO"
+	// NewPlayerID describes an event that the server sends to a client after
+	// making a new Player object for them. Clients need to know what their
+	// Player IDs are in order to include in the bodies of select events.
+	NewPlayerID EventKind = "NEW_PLAYER_ID"
 	// ChangeDisplayName describes an event that the client sends when they
 	// change their display name.
 	ChangeDisplayName EventKind = "CHANGE_DISPLAY_NAME"


### PR DESCRIPTION
In the bodies of select WS events that clients send to the server (most of which have yet to be implemented), a `Player`'s UUID needs to be included. This means that clients need to store this information.

This PR proposes to introduce a new `newPlayerID` WS event. The server is responsible for sending this event to a client once they first connect to a game lobby. The event body will contain the UUID that the server generated when it created a new `Player` object for the client. The client stores this UUID in the `user.id` section of the Redux global store.