### PR TITLE
Add event broadcasting functionality

### DIFF
--- a/server/api/ws.go
+++ b/server/api/ws.go
@@ -71,6 +71,7 @@ func (h *WSHandler) defaultHandler(w http.ResponseWriter, r *http.Request) {
 		newGame := model.NewGame(dictionary)
 		newInteractor := realtime.NewInteractor(newGame)
 		h.manager.ActiveGames[gameID] = newInteractor
+		go newInteractor.ListenForBroadcasts()
 	}
 
 	upgrader := websocket.Upgrader{}

--- a/server/api/ws.go
+++ b/server/api/ws.go
@@ -93,7 +93,7 @@ func (h *WSHandler) defaultHandler(w http.ResponseWriter, r *http.Request) {
 	// TODO: make this async by pushing this newPlayer pointer to some channel.
 	// This will break if more than one client hits the /ws endpoint at once
 	// with the same gameID.
-	newPlayer := realtime.NewPlayer(conn)
+	newPlayer := realtime.NewPlayer(conn, h.manager.ActiveGames[gameID])
 	h.manager.ActiveGames[gameID].Players[newPlayer.ID] = newPlayer
 	// Send the client a lobbyInfo event letting them know whether a game
 	// with the ID that they provided has already been created or not.

--- a/server/api/ws.go
+++ b/server/api/ws.go
@@ -93,7 +93,7 @@ func (h *WSHandler) defaultHandler(w http.ResponseWriter, r *http.Request) {
 	// This will break if more than one client hits the /ws endpoint at once
 	// with the same gameID.
 	newPlayer := realtime.NewPlayer(conn)
-	h.manager.ActiveGames[gameID].Players[newPlayer.DisplayName] = newPlayer
+	h.manager.ActiveGames[gameID].Players[newPlayer.ID] = newPlayer
 	// Send the client a lobbyInfo event letting them know whether a game
 	// with the ID that they provided has already been created or not.
 	lobbyInfoEventBody := map[string]bool{

--- a/server/api/ws.go
+++ b/server/api/ws.go
@@ -103,6 +103,7 @@ func (h *WSHandler) defaultHandler(w http.ResponseWriter, r *http.Request) {
 	realtime.ConstructAndSendEvent(conn, realtime.LobbyInfo, lobbyInfoEventBody)
 	// Begin listening for events sent to the server from the client.
 	go newPlayer.ListenForEvents()
+	go newPlayer.SendBroadcastedEventsToClient()
 }
 
 // RegisterRoutes registers handlers for all of the routes that wsHandler

--- a/server/realtime/interactor.go
+++ b/server/realtime/interactor.go
@@ -14,9 +14,8 @@ import (
 // associated with, or responsible for, each Game.
 type Interactor struct {
 	Game *model.Game
-
 	// Players stores Player objects for each active client, indexed by their
-	// display name.
+	// IDs.
 	Players map[string]*Player
 }
 

--- a/server/realtime/interactor.go
+++ b/server/realtime/interactor.go
@@ -4,11 +4,9 @@ import (
 	"github.com/nchaloult/codenames/model"
 )
 
-// Interactor manages Players that are playing in a Game, and facilitates events
-// through Websocket connections with all of those Players. When a Player
-// performs an action that triggers an event, whether that action be in an
-// ongoing game or a game lobby, an Interactor processes that event by mutating
-// the data model and notifying all other Players.
+// Interactor manages Players that are playing in a Game. When a Player triggers
+// an event that all other Players in a game need to know about, an Interactor
+// notifies those other Players by sending an event to each of them.
 //
 // Interactor and Game have a 1-1 relationship; there is one Interactor instance
 // associated with, or responsible for, each Game.
@@ -17,13 +15,43 @@ type Interactor struct {
 	// Players stores Player objects for each active client, indexed by their
 	// IDs.
 	Players map[string]*Player
+	// Events from a Player that are to be broadcasted to all other Players in a
+	// Game.
+	msgsToBroadcast chan *broadcastMsg
 }
 
 // NewInteractor returns a pointer to a new Interactor object initialized with
 // the provided game.
 func NewInteractor(game *model.Game) *Interactor {
 	return &Interactor{
-		Game:    game,
-		Players: make(map[string]*Player, 0),
+		Game:            game,
+		Players:         make(map[string]*Player, 0),
+		msgsToBroadcast: make(chan *broadcastMsg),
+	}
+}
+
+// ListenForBroadcasts watches the msgsToBroadcast channel for any new events.
+// When a new event appears, broadcast that event to all other Players in a Game
+// except for the Player who originally created that event.
+func (i *Interactor) ListenForBroadcasts() {
+	for {
+		select {
+		case msg := <-i.msgsToBroadcast:
+			for _, player := range i.Players {
+				if player.ID == msg.originClientID {
+					continue
+				}
+				select {
+				case player.broadcastedMsgs <- msg.event:
+					// No-op. Just push the broadcasted event onto each Player's
+					// chan.
+				default:
+					// TODO: better error handling. For now, just assume that
+					// this Player disconnected or something lol.
+					close(player.broadcastedMsgs)
+					delete(i.Players, player.ID)
+				}
+			}
+		}
 	}
 }

--- a/server/realtime/player.go
+++ b/server/realtime/player.go
@@ -91,7 +91,9 @@ func (p *Player) ListenForEvents() {
 		if err != nil {
 			log.Printf("Player %s websocket unexpected error: %v", p.ID, err)
 			p.Conn.Close()
-			// TODO: remove this Player from their Interactor.
+			// Remove this Player from their Interactor.
+			delete(p.interactor.Players, p.ID)
+			p.interactor = nil
 			return
 		}
 

--- a/server/realtime/player.go
+++ b/server/realtime/player.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// Artbitrarily chosen value. Regardless of how many Players are (realistically)
+// Arbitrarily chosen value. Regardless of how many Players are (realistically)
 // in a Game, I think it's pretty unlikely that 16 of those Players will all
 // need to broadcast an event at nearly the same time.
 const broadcastedMsgsBufferSize = 16

--- a/server/realtime/ws.go
+++ b/server/realtime/ws.go
@@ -35,6 +35,18 @@ type eventResponse struct {
 	Body interface{} `json:"body"`
 }
 
+// broadcastMsg objects are stored in an Interactor's broadcast channel. They
+// contain an event to be broadcasted to all Players in a Game except for the
+// Player who originally sent the event.
+type broadcastMsg struct {
+	// ID of the Player who originally sent the event. This is so that Players
+	// who send events that are broadcasted to everyone in a Game don't receive
+	// their own event.
+	originClientID string
+	// The event to broadcast to all other Players in a Game.
+	event *event
+}
+
 // ConstructAndSendEvent builds an event struct with the provided fields,
 // marshals it to JSON, and sends it along the provided Websocket connection.
 func ConstructAndSendEvent(conn *websocket.Conn, kind EventKind, body interface{}) {


### PR DESCRIPTION
Before implementing functionality concerning game lobbies (showing players switch teams and change their display names), support for broadcasting events to other players in a game needs to be ready first. This PR proposes to introduce functionality that allows the server to notify all `Player`s in a `Game` of an event.

In a `Player`'s logic for handling a particular type of WS event, they can broadcast a message to the other `Player`s in their `Game` with `Player.broadcastToOtherPlayers()`